### PR TITLE
Make clang figure out lld toolchain to avoid separating compilation and linking in two steps

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1,5 +1,11 @@
 //===--- Driver.cpp - Clang GCC Compatible Driver -------------------------===//
 //
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
 // Modified by Sunscreen under the AGPLv3 license; see the README at the
 // repository root for more information
 //

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1,8 +1,7 @@
 //===--- Driver.cpp - Clang GCC Compatible Driver -------------------------===//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Modified by Sunscreen under the AGPLv3 license; see the README at the
+// repository root for more information
 //
 //===----------------------------------------------------------------------===//
 
@@ -38,6 +37,7 @@
 #include "ToolChains/NetBSD.h"
 #include "ToolChains/OHOS.h"
 #include "ToolChains/OpenBSD.h"
+#include "ToolChains/Parasol.h"
 #include "ToolChains/PPCFreeBSD.h"
 #include "ToolChains/PPCLinux.h"
 #include "ToolChains/PS4CPU.h"
@@ -6380,6 +6380,9 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
         break;
       case llvm::Triple::csky:
         TC = std::make_unique<toolchains::CSKYToolChain>(*this, Target, Args);
+        break;
+      case llvm::Triple::parasol:
+        TC = std::make_unique<toolchains::ParasolToolChain>(*this, Target, Args);
         break;
       default:
         if (toolchains::BareMetal::handlesTarget(Target))

--- a/clang/lib/Driver/ToolChains/Parasol.cpp
+++ b/clang/lib/Driver/ToolChains/Parasol.cpp
@@ -32,3 +32,34 @@ bool ParasolToolChain::isPICDefaultForced() const { return true; }
 bool ParasolToolChain::SupportsProfiling() const { return false; }
 
 bool ParasolToolChain::hasBlocksRuntime() const { return false; }
+
+Tool *ParasolToolChain::buildLinker() const { return new ParasolLinker(*this); }
+
+bool ParasolLinker::hasIntegratedCPP() const { return false; }
+
+bool ParasolLinker::isLinkJob() const { return true; }
+
+void ParasolLinker::ConstructJob(Compilation &C, const JobAction &JA,
+                                 const InputInfo &Output, const InputInfoList &Inputs,
+                                 const ArgList &Args,
+                                 const char *LinkingOutput) const {
+  ArgStringList CmdArgs;
+
+  assert(Output.isFilename() && "Output must be a file");
+  CmdArgs.push_back("-o");
+  CmdArgs.push_back(Output.getFilename());
+
+  Args.AddAllArgValues(CmdArgs, options::OPT_Wa_COMMA, options::OPT_Xassembler);
+
+  for (const auto &Input : Inputs) {
+    assert(Input.getType() == types::TY_Object && Input.isFilename() && "Input must be an object file");
+    CmdArgs.push_back(Input.getFilename());
+  }
+
+  std::string Path(getToolChain().getDriver().getInstalledDir());
+  const char *Exec = Args.MakeArgString(Path + "/ld.lld");
+
+  C.addCommand(std::make_unique<Command>(JA, *this,
+                                         ResponseFileSupport::AtFileCurCP(),
+                                         Exec, CmdArgs, Inputs, Output));
+}

--- a/clang/lib/Driver/ToolChains/Parasol.h
+++ b/clang/lib/Driver/ToolChains/Parasol.h
@@ -9,6 +9,7 @@
 #define LLVM_CLANG_LIB_DRIVER_TOOLCHAINS_Parasol_H
 
 #include "Gnu.h"
+#include "clang/Driver/Tool.h"
 #include "clang/Driver/ToolChain.h"
 
 namespace clang {
@@ -37,6 +38,23 @@ public:
                                llvm::opt::ArgStringList &CC1Args) const override {}
   void AddCXXStdlibLibArgs(const llvm::opt::ArgList &Args,
                            llvm::opt::ArgStringList &CmdArgs) const override {}
+
+  Tool *buildLinker() const override;
+};
+
+class LLVM_LIBRARY_VISIBILITY ParasolLinker : public Tool {
+public:
+  ParasolLinker(const ToolChain &TC) : Tool("ParasolLinker", "linker", TC) {}
+
+  bool hasIntegratedCPP() const override;
+  bool isLinkJob() const override;
+  void
+  ConstructJob(Compilation &C,
+               const JobAction &JA,
+               const InputInfo &Output,
+               const InputInfoList &Inputs,
+               const llvm::opt::ArgList &TCArgs,
+               const char *LinkingOutput) const override;
 };
 
 } // end namespace toolchains

--- a/license-sunscreen-changes.txt
+++ b/license-sunscreen-changes.txt
@@ -29,6 +29,7 @@ clang/lib/Basic/Targets/Parasol.h
 clang/lib/CodeGen/CGCall.cpp
 clang/lib/CodeGen/CodeGenModule.cpp
 clang/lib/Driver/CMakeLists.txt
+clang/lib/Driver/Driver.cpp
 clang/lib/Driver/ToolChains/Parasol.cpp
 clang/lib/Driver/ToolChains/Parasol.h
 clang/lib/Sema/SemaDeclAttr.cpp


### PR DESCRIPTION
# Pull Request Checklist

Please ensure that your pull request addresses the following points:

- [ ] Have any of the opcode or instruction bit formatting changed in a breaking way?
    - If yes, please bump the ABI version in `llvm/lib/Target/Parasol/MCTargetDesc/ParasolELFObjectWriter.cpp`.
- [ ] Run `./format-parasol.sh` from the root directory to ensure your code is properly formatted.
- [ ] Updated the license-sunscreen-changes.txt with any changes to comply with the AGPLv3 and Apache licenses.
- [ ] Ensured that any files in this PR contain the Sunscreen license notice.

---

Thank you for your contribution to the Sunscreen LLVM fork!
