### PR TITLE
Use ZeroOrNegativeOneBooleanContent for boolean content in parasol

### DIFF
--- a/llvm/lib/Target/Parasol/ParasolISelLowering.cpp
+++ b/llvm/lib/Target/Parasol/ParasolISelLowering.cpp
@@ -69,7 +69,7 @@ ParasolTargetLowering::ParasolTargetLowering(const TargetMachine &TM,
   // use either RegPressure or Hybrid
   setSchedulingPreference(Sched::RegPressure);
 
-  setBooleanContents(ZeroOrOneBooleanContent);
+  setBooleanContents(ZeroOrNegativeOneBooleanContent);
   setBooleanVectorContents(ZeroOrOneBooleanContent);
 
   setOperationAction(ISD::GlobalAddress, MVT::i32, Custom);


### PR DESCRIPTION
With boolean content being either zero or -1, it is easier for us to handle encrypted data. This is because we can replicate the same encrypted bit to fill in a full byte. With the prior `ZeroOrOneBooleanContent` we would need to create trivial encryptions of zero, which means we needed to keep the encryption parameters around in our processor in undesirable places.