### PR TITLE
Use flake for getting latest release

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,19 @@ Please ensure that your pull request addresses the following points:
 - [ ] Updated the license-sunscreen-changes.txt with any changes to comply with the AGPLv3 and Apache licenses.
 - [ ] Ensured that any files in this PR contain the Sunscreen license notice.
 
+## Release Checklist (if creating a new release)
+
+If this PR is for creating a new release, please complete the following:
+
+- [ ] Update the version in `sunscreen-llvm.nix` (format: YYYY.MM.DD)
+- [ ] Run `./package-release.sh` for all supported architectures:
+    - [ ] macOS aarch64
+    - [ ] Linux aarch64
+    - [ ] Linux x86-64
+- [ ] Update SHA256 hashes in `sunscreen-llvm.nix` for all three tarballs
+- [ ] Follow the tag naming format: vYYYY.MM.DD (e.g., v2025.09.30)
+- [ ] Create GitHub release with all tarballs attached
+
 ---
 
 Thank you for your contribution to the Sunscreen LLVM fork!

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,4 @@
+# Modified by Sunscreen under the AGPLv3 license; see the README at the
+# repository root for more information
+
+import ./sunscreen-llvm.nix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1760504863,
+        "narHash": "sha256-h13YFQMi91nXkkRoJMIfezorz5SbD6849jw5L0fjK4I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "82c2e0d6dde50b17ae366d2aa36f224dc19af469",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,84 @@
+# Modified by Sunscreen under the AGPLv3 license; see the README at the
+# repository root for more information
+
+{
+  description = "Sunscreen LLVM compiler for parasol target (FHE compilation)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        # Sunscreen LLVM compiler for parasol target
+        sunscreen-llvm = pkgs.callPackage ./sunscreen-llvm.nix { };
+
+        # Helper script to run compile-llvm.sh from anywhere
+        compile-llvm = pkgs.writeShellScriptBin "compile-llvm" ''
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          # Get the root directory of the git repository
+          ROOT_DIR=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
+
+          # Run the compile-llvm.sh script in the root directory
+          "$ROOT_DIR/compile-llvm.sh" "$@"
+        '';
+
+        # Helper script to run format-parasol.sh from anywhere
+        format-parasol = pkgs.writeShellScriptBin "format-parasol" ''
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          # Get the root directory of the git repository
+          ROOT_DIR=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
+
+          # Run the format-parasol.sh script in the root directory
+          "$ROOT_DIR/format-parasol.sh" "$@"
+        '';
+
+      in {
+        packages = {
+          inherit sunscreen-llvm;
+          default = sunscreen-llvm;
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${sunscreen-llvm}/bin/clang";
+        };
+
+        checks = {
+          inherit sunscreen-llvm;
+        };
+
+        devShells.default = pkgs.mkShellNoCC {
+          buildInputs = [
+            # Build tools
+            pkgs.ninja
+            pkgs.diffoscopeMinimal
+
+            # Helper scripts
+            compile-llvm
+            format-parasol
+          ];
+
+          shellHook = ''
+            echo "Sunscreen LLVM development environment loaded."
+            echo ""
+            echo "Available tools:"
+            echo "  compile-llvm     - Compile LLVM from source"
+            echo "  format-parasol   - Format Parasol-specific code"
+            echo "  ninja            - Build system"
+            echo "  diffoscope       - Binary comparison tool"
+            echo ""
+            echo "To use the pre-built sunscreen-llvm compiler in your project,"
+            echo "add it to your flake inputs or use nix-shell with sunscreen-llvm.nix"
+          '';
+        };
+      });
+}

--- a/license-sunscreen-changes.txt
+++ b/license-sunscreen-changes.txt
@@ -17,8 +17,11 @@ README.md
 compile.sh
 run-all.sh
 run.sh
-shell.nix
 package-release.sh
+flake.nix
+flake.lock
+default.nix
+sunscreen-llvm.nix
 clang/include/clang/AST/Type.h
 clang/include/clang/Basic/Attr.td
 clang/include/clang/Basic/AttrDocs.td

--- a/sunscreen-llvm.nix
+++ b/sunscreen-llvm.nix
@@ -1,0 +1,67 @@
+# Modified by Sunscreen under the AGPLv3 license; see the README at the
+# repository root for more information
+
+{ lib, stdenv, fetchurl, autoPatchelfHook, zlib }:
+
+let
+  version = "2025.09.30";
+  fileVersion = builtins.replaceStrings [ "." ] [ "-" ] version;
+  urlBase =
+    "https://github.com/Sunscreen-tech/sunscreen-llvm/releases/download/v${version}";
+
+in stdenv.mkDerivation rec {
+  pname = "sunscreen-llvm";
+  inherit version;
+
+  src = if stdenv.isDarwin then
+    fetchurl {
+      url = "${urlBase}/parasol-compiler-macos-aarch64-${fileVersion}.tar.gz";
+      sha256 = "0ra93mji3j9km7ia21gsqswn49a3abwc1ml1xq643hzq4xigyqjd";
+    }
+  else if stdenv.isLinux && stdenv.isAarch64 then
+    fetchurl {
+      url = "${urlBase}/parasol-compiler-linux-aarch64-${fileVersion}.tar.gz";
+      sha256 = "197fybbjvimnyqwwn3q7s9yrljbqp57s42n9znpckmnbcbp8p373";
+    }
+  else if stdenv.isLinux && stdenv.isx86_64 then
+    fetchurl {
+      url = "${urlBase}/parasol-compiler-linux-x86-64-${fileVersion}.tar.gz";
+      sha256 = "1p0418nqzs6a2smrbqiyrxj34pimm6qzj7k29l4ys226cz6kfz2r";
+    }
+  else
+    throw "Unsupported platform: ${stdenv.system}";
+
+  strictDeps = true;
+
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+
+  buildInputs = lib.optionals stdenv.isLinux [
+    stdenv.cc.cc.lib # Provides libstdc++ and libgcc_s
+    zlib
+  ];
+
+  # The tarball extracts to current directory, not a subdirectory
+  sourceRoot = ".";
+
+  # Don't run configure or build - this is a binary package
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r * $out/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description =
+      "Sunscreen LLVM compiler for parasol target (FHE compilation)";
+    homepage = "https://github.com/Sunscreen-tech/sunscreen-llvm";
+    license = licenses.agpl3Only;
+    platforms = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
+    mainProgram = "clang";
+  };
+}


### PR DESCRIPTION
This allows the repository to be used as an input to a nix flake, enabling the binary to be available to other nix environments that use this compiler

# Pull Request Checklist

Please ensure that your pull request addresses the following points:

- [ ] Have any of the opcode or instruction bit formatting changed in a breaking way?
    - If yes, please bump the ABI version in `llvm/lib/Target/Parasol/MCTargetDesc/ParasolELFObjectWriter.cpp`.
- [ ] Run `./format-parasol.sh` from the root directory to ensure your code is properly formatted.
- [x] Updated the license-sunscreen-changes.txt with any changes to comply with the AGPLv3 and Apache licenses.
- [x] Ensured that any files in this PR contain the Sunscreen license notice.

---

Thank you for your contribution to the Sunscreen LLVM fork!
