### PR TITLE
sum specify accumulator size

### DIFF
--- a/clang/lib/Headers/parasol.h
+++ b/clang/lib/Headers/parasol.h
@@ -374,8 +374,8 @@ static inline bool get_bit32(uint32_t value, unsigned int n) {
   }
 
 // Tree reduction for sum - uses wider accumulator to reduce overflow risk
-#define DEFINE_SUM_ARRAY(SUFFIX, INPUT_TYPE, SUM_TYPE)                         \
-  static inline SUM_TYPE sum##SUFFIX##_array(                                  \
+#define DEFINE_SUM_ARRAY(NAME, INPUT_TYPE, SUM_TYPE)                           \
+  static inline SUM_TYPE NAME##_array(                                         \
       const INPUT_TYPE *arr, uint16_t len, SUM_TYPE *scratch) {                \
     for (uint32_t i = 0; i < len; i++) {                                       \
       scratch[i] = (SUM_TYPE)arr[i];                                           \
@@ -441,7 +441,6 @@ static inline bool get_bit32(uint32_t value, unsigned int n) {
 #define GENERATE_ARRAY_OPS_UNSIGNED(BITS)                                      \
   DEFINE_MIN_ARRAY(BITS, uint##BITS##_t, select##BITS)                         \
   DEFINE_MAX_ARRAY(BITS, uint##BITS##_t, select##BITS)                         \
-  DEFINE_SUM_ARRAY(BITS, uint##BITS##_t, uint64_t)                             \
   DEFINE_COMPARE_SWAP(uint##BITS, uint##BITS##_t, select##BITS)                \
   DEFINE_BITONIC_SORT(uint##BITS, uint##BITS##_t)
 
@@ -490,37 +489,44 @@ static inline bool get_bit32(uint32_t value, unsigned int n) {
     return scratch[0];                                                         \
   }
 
-#define DEFINE_SUM_ARRAY_SIGNED(BITS)                                          \
-  static inline int64_t isum##BITS##_array(const int##BITS##_t *arr,           \
-                                           uint16_t len, int64_t *scratch) {   \
-    for (uint32_t i = 0; i < len; i++) {                                       \
-      scratch[i] = (int64_t)arr[i];                                            \
-    }                                                                          \
-    for (uint32_t current_len = len; current_len > 1;) {                       \
-      uint32_t next_len = current_len / 2;                                     \
-      for (uint32_t i = 0; i < next_len; i++) {                                \
-        scratch[i] = scratch[2 * i] + scratch[2 * i + 1];                      \
-      }                                                                        \
-      if (current_len % 2 == 1) {                                              \
-        scratch[next_len] = scratch[current_len - 1];                          \
-        next_len++;                                                            \
-      }                                                                        \
-      current_len = next_len;                                                  \
-    }                                                                          \
-    return scratch[0];                                                         \
-  }
-
 // Generate functions for signed types
 #define GENERATE_ARRAY_OPS_SIGNED(BITS)                                        \
   DEFINE_MIN_ARRAY_SIGNED(BITS)                                                \
   DEFINE_MAX_ARRAY_SIGNED(BITS)                                                \
-  DEFINE_SUM_ARRAY_SIGNED(BITS)                                                \
   DEFINE_COMPARE_SWAP(int##BITS, int##BITS##_t, iselect##BITS)                 \
   DEFINE_BITONIC_SORT(int##BITS, int##BITS##_t)
 
 GENERATE_ARRAY_OPS_UNSIGNED(8)
 GENERATE_ARRAY_OPS_UNSIGNED(16)
 GENERATE_ARRAY_OPS_UNSIGNED(32)
+
+// Sum functions for unsigned types
+// Function naming: sum<input_bits>_<output_bits>_array
+//
+// Choosing accumulator size:
+//   - Known small arrays or bounded sums: use smallest safe accumulator
+//   - Unknown/dynamic array sizes: use next larger accumulator for safety margin
+//   - Critical correctness requirements: use largest accumulator (64-bit)
+//   - Performance-critical with validated bounds: use matching-size accumulator
+//
+// Overflow safety: max_safe_elements = MAX_ACCUMULATOR / MAX_INPUT_VALUE
+//   Example: sum8_16 safe for 65535/255 = 257 elements of max value
+
+// 8-bit input sum functions
+DEFINE_SUM_ARRAY(sum8_16, uint8_t, uint16_t)   // Up to 257 elements of max value (255)
+DEFINE_SUM_ARRAY(sum8_32, uint8_t, uint32_t)   // Up to 16M elements of max value
+DEFINE_SUM_ARRAY(sum8_64, uint8_t, uint64_t)   // Maximum safety (72+ quadrillion elements)
+
+// 16-bit input sum functions
+DEFINE_SUM_ARRAY(sum16_32, uint16_t, uint32_t) // Up to 65537 elements of max value (65535)
+DEFINE_SUM_ARRAY(sum16_64, uint16_t, uint64_t) // Maximum safety (281+ trillion elements)
+
+// 32-bit input sum functions
+DEFINE_SUM_ARRAY(sum32_64, uint32_t, uint64_t) // Safe default (4+ billion elements of max value)
+DEFINE_SUM_ARRAY(sum32_32, uint32_t, uint32_t) // Performance option (overflow possible, use with care)
+
+// 64-bit input sum function
+DEFINE_SUM_ARRAY(sum64_64, uint64_t, uint64_t) // Same size (no 128-bit available, overflow possible)
 
 // Generate 64-bit unsigned functions except sum (sum64 would overflow without 128-bit accumulator)
 DEFINE_MIN_ARRAY(64, uint64_t, select64)
@@ -531,6 +537,30 @@ DEFINE_BITONIC_SORT(uint64, uint64_t)
 GENERATE_ARRAY_OPS_SIGNED(8)
 GENERATE_ARRAY_OPS_SIGNED(16)
 GENERATE_ARRAY_OPS_SIGNED(32)
+
+// Sum functions for signed types
+// Function naming: isum<input_bits>_<output_bits>_array
+// See unsigned sum functions above for accumulator size selection guidance
+//
+// Overflow safety for signed: check both positive and negative bounds
+//   Positive: max_safe_elements = MAX_ACCUMULATOR / MAX_INPUT_VALUE
+//   Negative: max_safe_elements = abs(MIN_ACCUMULATOR) / abs(MIN_INPUT_VALUE)
+
+// 8-bit input sum functions
+DEFINE_SUM_ARRAY(isum8_16, int8_t, int16_t)   // Up to 257 elements (32767/127, 32768/128)
+DEFINE_SUM_ARRAY(isum8_32, int8_t, int32_t)   // Up to 16M elements of extreme values
+DEFINE_SUM_ARRAY(isum8_64, int8_t, int64_t)   // Maximum safety
+
+// 16-bit input sum functions
+DEFINE_SUM_ARRAY(isum16_32, int16_t, int32_t) // Up to 65537 elements of extreme values
+DEFINE_SUM_ARRAY(isum16_64, int16_t, int64_t) // Maximum safety
+
+// 32-bit input sum functions
+DEFINE_SUM_ARRAY(isum32_64, int32_t, int64_t) // Safe default (4+ billion elements)
+DEFINE_SUM_ARRAY(isum32_32, int32_t, int32_t) // Performance option (overflow possible, use with care)
+
+// 64-bit input sum function
+DEFINE_SUM_ARRAY(isum64_64, int64_t, int64_t) // Same size (no 128-bit available, overflow possible)
 
 // Generate 64-bit signed functions except sum (isum64 would overflow without 128-bit accumulator)
 DEFINE_MIN_ARRAY_SIGNED(64)

--- a/parasol-tests/test_array_reductions.c
+++ b/parasol-tests/test_array_reductions.c
@@ -34,13 +34,13 @@ static int fail_count = 0;
 
 // Macro-based property test generation for array reductions
 // Eliminates duplication across uint16/32/64 and int16/32/64 property tests
-#define DEFINE_UNSIGNED_REDUCTION_PROPERTY_TEST(BITS, MAX_LEN, RAND_EXPR)      \
+#define DEFINE_UNSIGNED_REDUCTION_PROPERTY_TEST(BITS, SUM_FUNC, SUM_TYPE, MAX_LEN, RAND_EXPR) \
   static void test_uint##BITS##_properties(void) {                             \
     TEST("uint" #BITS " min/max/sum properties");                          \
                                                                                \
     uint##BITS##_t *arr = malloc(MAX_LEN * sizeof(uint##BITS##_t));            \
     uint##BITS##_t *scratch_minmax = malloc(MAX_LEN * sizeof(uint##BITS##_t)); \
-    uint64_t *scratch_sum = malloc(MAX_LEN * sizeof(uint64_t));                \
+    SUM_TYPE *scratch_sum = malloc(MAX_LEN * sizeof(SUM_TYPE));                \
                                                                                \
     for (int trial = 0; trial < PROPERTY_TEST_TRIALS; trial++) {               \
       uint16_t len = 1 + (rand() % MAX_LEN);                                   \
@@ -51,11 +51,11 @@ static int fail_count = 0;
                                                                                \
       uint##BITS##_t min_result = min##BITS##_array(arr, len, scratch_minmax); \
       uint##BITS##_t max_result = max##BITS##_array(arr, len, scratch_minmax); \
-      uint64_t sum_result = sum##BITS##_array(arr, len, scratch_sum);          \
+      SUM_TYPE sum_result = SUM_FUNC##_array(arr, len, scratch_sum);           \
                                                                                \
       bool min_found = false;                                                  \
       bool max_found = false;                                                  \
-      uint64_t sum_check = 0;                                                  \
+      SUM_TYPE sum_check = 0;                                                  \
                                                                                \
       for (uint16_t i = 0; i < len; i++) {                                     \
         if (arr[i] < min_result) {                                             \
@@ -99,13 +99,13 @@ static int fail_count = 0;
     free(scratch_sum);                                                         \
   }
 
-#define DEFINE_SIGNED_REDUCTION_PROPERTY_TEST(BITS, MAX_LEN, RAND_EXPR)        \
+#define DEFINE_SIGNED_REDUCTION_PROPERTY_TEST(BITS, SUM_FUNC, SUM_TYPE, MAX_LEN, RAND_EXPR) \
   static void test_int##BITS##_properties(void) {                              \
     TEST("int" #BITS " min/max/sum properties");                           \
                                                                                \
     int##BITS##_t *arr = malloc(MAX_LEN * sizeof(int##BITS##_t));              \
     int##BITS##_t *scratch_minmax = malloc(MAX_LEN * sizeof(int##BITS##_t));   \
-    int64_t *scratch_sum = malloc(MAX_LEN * sizeof(int64_t));                  \
+    SUM_TYPE *scratch_sum = malloc(MAX_LEN * sizeof(SUM_TYPE));                \
                                                                                \
     for (int trial = 0; trial < PROPERTY_TEST_TRIALS; trial++) {               \
       uint16_t len = 1 + (rand() % MAX_LEN);                                   \
@@ -116,11 +116,11 @@ static int fail_count = 0;
                                                                                \
       int##BITS##_t min_result = imin##BITS##_array(arr, len, scratch_minmax); \
       int##BITS##_t max_result = imax##BITS##_array(arr, len, scratch_minmax); \
-      int64_t sum_result = isum##BITS##_array(arr, len, scratch_sum);          \
+      SUM_TYPE sum_result = SUM_FUNC##_array(arr, len, scratch_sum);           \
                                                                                \
       bool min_found = false;                                                  \
       bool max_found = false;                                                  \
-      int64_t sum_check = 0;                                                   \
+      SUM_TYPE sum_check = 0;                                                  \
                                                                                \
       for (uint16_t i = 0; i < len; i++) {                                     \
         if (arr[i] < min_result) {                                             \
@@ -160,6 +160,15 @@ static int fail_count = 0;
     free(scratch_sum);                                                         \
   }
 
+// Instantiate property tests for different bit widths
+DEFINE_UNSIGNED_REDUCTION_PROPERTY_TEST(8, sum8_32, uint32_t, 1000, (uint8_t)(rand() % 256))
+DEFINE_UNSIGNED_REDUCTION_PROPERTY_TEST(16, sum16_32, uint32_t, 500, (uint16_t)rand())
+DEFINE_UNSIGNED_REDUCTION_PROPERTY_TEST(32, sum32_64, uint64_t, 500, (uint32_t)rand())
+
+DEFINE_SIGNED_REDUCTION_PROPERTY_TEST(8, isum8_32, int32_t, 1000, (int8_t)((rand() % 256) - 128))
+DEFINE_SIGNED_REDUCTION_PROPERTY_TEST(16, isum16_32, int32_t, 500, (int16_t)(rand() - (RAND_MAX/2)))
+DEFINE_SIGNED_REDUCTION_PROPERTY_TEST(32, isum32_64, int64_t, 500, (int32_t)(rand() - (RAND_MAX/2)))
+
 // Reference implementations for comparison
 static uint8_t min_naive_uint8(const uint8_t *arr, uint16_t len) {
   uint8_t result = arr[0];
@@ -179,8 +188,8 @@ static uint8_t max_naive_uint8(const uint8_t *arr, uint16_t len) {
   return result;
 }
 
-static uint64_t sum_naive_uint8(const uint8_t *arr, uint16_t len) {
-  uint64_t result = 0;
+static uint32_t sum_naive_uint8(const uint8_t *arr, uint16_t len) {
+  uint32_t result = 0;
   for (uint16_t i = 0; i < len; i++) {
     result += arr[i];
   }
@@ -205,8 +214,8 @@ static int8_t max_naive_int8(const int8_t *arr, uint16_t len) {
   return result;
 }
 
-static int64_t sum_naive_int8(const int8_t *arr, uint16_t len) {
-  int64_t result = 0;
+static int32_t sum_naive_int8(const int8_t *arr, uint16_t len) {
+  int32_t result = 0;
   for (uint16_t i = 0; i < len; i++) {
     result += arr[i];
   }
@@ -316,36 +325,36 @@ static void test_comparison_naive(void) {
 
   uint8_t arr[] = {42, 17, 99, 3, 85, 61, 28};
   uint8_t scratch[7];
-  uint64_t scratch_sum[7];
+  uint32_t scratch_sum[7];
 
   uint8_t min_result = min8_array(arr, 7, scratch);
   uint8_t max_result = max8_array(arr, 7, scratch);
-  uint64_t sum_result = sum8_array(arr, 7, scratch_sum);
+  uint32_t sum_result = sum8_32_array(arr, 7, scratch_sum);
 
   uint8_t min_expected = min_naive_uint8(arr, 7);
   uint8_t max_expected = max_naive_uint8(arr, 7);
-  uint64_t sum_expected = sum_naive_uint8(arr, 7);
+  uint32_t sum_expected = sum_naive_uint8(arr, 7);
 
   if (min_result != min_expected || max_result != max_expected ||
       sum_result != sum_expected) {
-    FAIL("mismatch with naive: min %u!=%u max %u!=%u sum %llu!=%llu",
+    FAIL("mismatch with naive: min %u!=%u max %u!=%u sum %u!=%u",
          min_result, min_expected, max_result, max_expected,
-         (unsigned long long)sum_result, (unsigned long long)sum_expected);
+         sum_result, sum_expected);
     return;
   }
 
   // Test int8
   int8_t arr_signed[] = {-42, 17, -99, 3, 85, -61, 28};
   int8_t scratch_signed[7];
-  int64_t scratch_sum_signed[7];
+  int32_t scratch_sum_signed[7];
 
   int8_t min_signed = imin8_array(arr_signed, 7, scratch_signed);
   int8_t max_signed = imax8_array(arr_signed, 7, scratch_signed);
-  int64_t sum_signed = isum8_array(arr_signed, 7, scratch_sum_signed);
+  int32_t sum_signed = isum8_32_array(arr_signed, 7, scratch_sum_signed);
 
   int8_t min_signed_expected = min_naive_int8(arr_signed, 7);
   int8_t max_signed_expected = max_naive_int8(arr_signed, 7);
-  int64_t sum_signed_expected = sum_naive_int8(arr_signed, 7);
+  int32_t sum_signed_expected = sum_naive_int8(arr_signed, 7);
 
   if (min_signed != min_signed_expected || max_signed != max_signed_expected ||
       sum_signed != sum_signed_expected) {
@@ -366,7 +375,7 @@ static void test_non_power_of_2(void) {
     uint16_t len = sizes[s];
     uint8_t *arr = malloc(len * sizeof(uint8_t));
     uint8_t *scratch = malloc(len * sizeof(uint8_t));
-    uint64_t *scratch_sum = malloc(len * sizeof(uint64_t));
+    uint32_t *scratch_sum = malloc(len * sizeof(uint32_t));
 
     // Sequential values
     for (uint16_t i = 0; i < len; i++) {
@@ -375,11 +384,11 @@ static void test_non_power_of_2(void) {
 
     uint8_t min_result = min8_array(arr, len, scratch);
     uint8_t max_result = max8_array(arr, len, scratch);
-    uint64_t sum_result = sum8_array(arr, len, scratch_sum);
+    uint32_t sum_result = sum8_32_array(arr, len, scratch_sum);
 
     uint8_t min_expected = min_naive_uint8(arr, len);
     uint8_t max_expected = max_naive_uint8(arr, len);
-    uint64_t sum_expected = sum_naive_uint8(arr, len);
+    uint32_t sum_expected = sum_naive_uint8(arr, len);
 
     if (min_result != min_expected || max_result != max_expected ||
         sum_result != sum_expected) {
@@ -408,6 +417,14 @@ int main() {
   test_int8_min_max();
   test_comparison_naive();
   test_non_power_of_2();
+
+  printf("\nProperty-Based Tests\n");
+  test_uint8_properties();
+  test_uint16_properties();
+  test_uint32_properties();
+  test_int8_properties();
+  test_int16_properties();
+  test_int32_properties();
 
   printf("\nResults: %d passed, %d failed\n", pass_count, fail_count);
 

--- a/parasol-tests/test_parasol_compilation.c
+++ b/parasol-tests/test_parasol_compilation.c
@@ -72,12 +72,24 @@ void *max_array_functions[] = {
 };
 
 void *sum_array_functions[] = {
-    (void *)sum8_array,
-    (void *)sum16_array,
-    (void *)sum32_array,
-    (void *)isum8_array,
-    (void *)isum16_array,
-    (void *)isum32_array,
+    // Unsigned sum functions with various accumulator sizes
+    (void *)sum8_16_array,
+    (void *)sum8_32_array,
+    (void *)sum8_64_array,
+    (void *)sum16_32_array,
+    (void *)sum16_64_array,
+    (void *)sum32_64_array,
+    (void *)sum32_32_array,
+    (void *)sum64_64_array,
+    // Signed sum functions with various accumulator sizes
+    (void *)isum8_16_array,
+    (void *)isum8_32_array,
+    (void *)isum8_64_array,
+    (void *)isum16_32_array,
+    (void *)isum16_64_array,
+    (void *)isum32_64_array,
+    (void *)isum32_32_array,
+    (void *)isum64_64_array,
 };
 
 void *compare_swap_functions[] = {

--- a/sunscreen-llvm.nix
+++ b/sunscreen-llvm.nix
@@ -16,17 +16,17 @@ in stdenv.mkDerivation rec {
   src = if stdenv.isDarwin then
     fetchurl {
       url = "${urlBase}/parasol-compiler-macos-aarch64-${fileVersion}.tar.gz";
-      sha256 = "15bskb9y7chwsxyc60rknkg8fg7zpqar3shhg98v4fhn7c153bn5";
+      sha256 = "0i68wmn0xa9q946yn116bzg3522gnf59i53kcr42yqmc9lyrvpn3";
     }
   else if stdenv.isLinux && stdenv.isAarch64 then
     fetchurl {
       url = "${urlBase}/parasol-compiler-linux-aarch64-${fileVersion}.tar.gz";
-      sha256 = "0illxpr115jih1fsd8sfxg67231bbjygfwnyr3srvypppywlyy6d";
+      sha256 = "11sg7ljrp34skizbjr6jp7jy1v08m0bk0353j1sq4dnifrwsgpyv";
     }
   else if stdenv.isLinux && stdenv.isx86_64 then
     fetchurl {
       url = "${urlBase}/parasol-compiler-linux-x86-64-${fileVersion}.tar.gz";
-      sha256 = "1bqkjra0czp9111idnwqpd1mj218gihh2wqisbrfwfl2pqn7c7wi";
+      sha256 = "1wc8h33c21i397sy54j38k1vgcp3jvan0mlj5dgbcgdsdirwgfmy";
     }
   else
     throw "Unsupported platform: ${stdenv.system}";


### PR DESCRIPTION
- Add sum array functions with explicit accumulator size control (e.g., sum8_16_array, sum8_32_array) allowing users to choose performance vs safety tradeoffs for FHE applications
- Unify sum function implementation using single DEFINE_SUM_ARRAY macro, add comprehensive overflow documentation, and implement property-based tests for all variants

# Pull Request Checklist

Please ensure that your pull request addresses the following points:

- [ ] Have any of the opcode or instruction bit formatting changed in a breaking way?
    - If yes, please bump the ABI version in `llvm/lib/Target/Parasol/MCTargetDesc/ParasolELFObjectWriter.cpp`.
- [ ] Run `./format-parasol.sh` from the root directory to ensure your code is properly formatted.
- [ ] Updated the license-sunscreen-changes.txt with any changes to comply with the AGPLv3 and Apache licenses.
- [ ] Ensured that any files in this PR contain the Sunscreen license notice.

## Release Checklist (if creating a new release)

If this PR is for creating a new release, use `./release-all.sh` to build all architectures and update the Nix configuration:

```bash
./release-all.sh              # Uses today's date
./release-all.sh 2025.11.21   # Custom version
```

The script builds macOS (native) and Linux (Docker) tarballs, calculates hashes, and updates `sunscreen-llvm.nix`.

Before merging:
- [ ] Review changes: `git diff sunscreen-llvm.nix`
- [ ] Commit: `git add sunscreen-llvm.nix && git commit -m 'chore: release vYYYY.MM.DD'`

After PR is merged:
- [ ] Create tag on main branch: `git tag vYYYY.MM.DD`
- [ ] Push tag: `git push origin vYYYY.MM.DD`
- [ ] Create GitHub release with tarballs from `releases/` directory

---

Thank you for your contribution to the Sunscreen LLVM fork!
