### PR TITLE
Fix parasol.h to use the correctly defined macro

### DIFF
--- a/clang/lib/Basic/Targets/Parasol.cpp
+++ b/clang/lib/Basic/Targets/Parasol.cpp
@@ -44,8 +44,8 @@ ArrayRef<TargetInfo::GCCRegAlias> ParasolTargetInfo::getGCCRegAliases() const {
 
 void ParasolTargetInfo::getTargetDefines(const LangOptions &Opts,
                                        MacroBuilder &Builder) const {
-  // Define the __Parasol__ macro when building for this target
-  Builder.defineMacro("__Parasol__");
+  // Define the __PARASOL__ macro when building for this target
+  Builder.defineMacro("__PARASOL__");
 }
 
 bool ParasolTargetInfo::validateAsmConstraint(

--- a/clang/lib/Headers/parasol.h
+++ b/clang/lib/Headers/parasol.h
@@ -27,7 +27,7 @@ typedef long long int64_t;
 // On Parasol target: use FHE-friendly cmux instruction
 // On other targets: use standard ternary operator
 
-#if defined(__Parasol__)
+#if defined(__PARASOL__)
 // FHE-friendly conditional selector using inline assembly
 #define DEFINE_SELECT(BITS)                                                    \
   static inline uint##BITS##_t select##BITS(bool cond, uint##BITS##_t a,       \

--- a/clang/lib/Headers/parasol.h
+++ b/clang/lib/Headers/parasol.h
@@ -27,7 +27,7 @@ typedef long long int64_t;
 // On Parasol target: use FHE-friendly cmux instruction
 // On other targets: use standard ternary operator
 
-#if defined(__parasol__)
+#if defined(__Parasol__)
 // FHE-friendly conditional selector using inline assembly
 #define DEFINE_SELECT(BITS)                                                    \
   static inline uint##BITS##_t select##BITS(bool cond, uint##BITS##_t a,       \


### PR DESCRIPTION
Most macros are all upper or all lower, but some is using this