### PR TITLE
feat: add 64-bit and 128-bit constant support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,5 +241,6 @@ $RECYCLE.BIN/
 
 # End of https://www.toptal.com/developers/gitignore/api/emacs,vim,visualstudiocode,macos,windows,linux,direnv
 .claude/
+CLAUDE.md
 releases/
 sunscreen-llvm-source.tar.gz

--- a/clang/lib/Headers/parasol.h
+++ b/clang/lib/Headers/parasol.h
@@ -22,6 +22,10 @@ typedef unsigned int uint32_t;
 typedef int int32_t;
 typedef unsigned long long uint64_t;
 typedef long long int64_t;
+#ifdef __SIZEOF_INT128__
+typedef unsigned __int128 uint128_t;
+typedef __int128 int128_t;
+#endif
 
 // Conditional selector functions
 // On Parasol target: use FHE-friendly cmux instruction
@@ -70,7 +74,8 @@ DEFINE_SELECT(32)
 DEFINE_SELECT(64)
 
 // Absolute value functions (signed)
-// Note: abs64 omitted - requires 64-bit shift operation (>> 63) not supported by parasol target
+// Note: abs64 omitted - requires 64-bit shift operation (>> 63) not supported
+// by parasol target
 #define abs8(x) iselect8((x) < 0, -(x), (x))
 #define abs16(x) iselect16((x) < 0, -(x), (x))
 #define abs32(x) iselect32((x) < 0, -(x), (x))
@@ -134,10 +139,10 @@ DEFINE_SQRT(sqrt32, uint32_t, uint16_t, 32768, select16)
 #define iclamp64(x, min_val, max_val) imin64(imax64((x), (min_val)), (max_val))
 
 // Sign functions - Returns -1, 0, or 1 based on sign
-// Note: sign64 omitted - generates 64-bit constant (-1) not supported by parasol target
 #define sign8(x) iselect8((x) < 0, -1, iselect8((x) > 0, 1, 0))
 #define sign16(x) iselect16((x) < 0, -1, iselect16((x) > 0, 1, 0))
 #define sign32(x) iselect32((x) < 0, -1, iselect32((x) > 0, 1, 0))
+#define sign64(x) iselect64((x) < 0, -1LL, iselect64((x) > 0, 1LL, 0LL))
 
 // Conditional swap - Swaps values if condition is true
 #define cswap8(cond, a, b)                                                     \
@@ -206,7 +211,8 @@ DEFINE_SQRT(sqrt32, uint32_t, uint16_t, 32768, select16)
   } while (0)
 
 // Average/midpoint functions (unsigned) - Avoids overflow
-// Note: avg64 omitted - requires 64-bit shift operation (>> 1) not supported by parasol target
+// Note: avg64 omitted - requires 64-bit shift operation (>> 1) not supported by
+// parasol target
 #define avg8(a, b) ((uint8_t)(((a) & (b)) + (((a) ^ (b)) >> 1)))
 #define avg16(a, b) ((uint16_t)(((a) & (b)) + (((a) ^ (b)) >> 1)))
 #define avg32(a, b) ((uint32_t)(((a) & (b)) + (((a) ^ (b)) >> 1)))
@@ -217,20 +223,23 @@ DEFINE_SQRT(sqrt32, uint32_t, uint16_t, 32768, select16)
 #define absdiff32(a, b) select32((a) > (b), (a) - (b), (b) - (a))
 #define absdiff64(a, b) select64((a) > (b), (a) - (b), (b) - (a))
 
-// Note: iabsdiff64 omitted - generates 64-bit shift (>> 63) during optimization, not supported by parasol target
+// Note: iabsdiff64 omitted - generates 64-bit shift (>> 63) during
+// optimization, not supported by parasol target
 #define iabsdiff8(a, b) ((uint8_t)iselect8((a) > (b), (a) - (b), (b) - (a)))
 #define iabsdiff16(a, b) ((uint16_t)iselect16((a) > (b), (a) - (b), (b) - (a)))
 #define iabsdiff32(a, b) ((uint32_t)iselect32((a) > (b), (a) - (b), (b) - (a)))
 
 // Saturating arithmetic (clamps instead of wrapping on overflow/underflow)
-// Note: sadd64, ssub64 omitted - require 64-bit constants not supported by parasol target
-#define sadd8(a, b) select8((a) > (uint8_t)(255U - (b)), 255, (a) + (b))
-#define sadd16(a, b) select16((a) > (uint16_t)(65535U - (b)), 65535, (a) + (b))
-#define sadd32(a, b) select32((a) > (4294967295U - (b)), 4294967295U, (a) + (b))
+#define sadd8(a, b) select8((a) > (uint8_t)(0xFFU - (b)), 0xFF, (a) + (b))
+#define sadd16(a, b) select16((a) > (uint16_t)(0xFFFFU - (b)), 0xFFFF, (a) + (b))
+#define sadd32(a, b) select32((a) > (0xFFFFFFFFU - (b)), 0xFFFFFFFFU, (a) + (b))
+#define sadd64(a, b)                                                           \
+  select64((a) > (0xFFFFFFFFFFFFFFFFULL - (b)), 0xFFFFFFFFFFFFFFFFULL, (a) + (b))
 
 #define ssub8(a, b) select8((a) < (b), 0, (a) - (b))
 #define ssub16(a, b) select16((a) < (b), 0, (a) - (b))
 #define ssub32(a, b) select32((a) < (b), 0, (a) - (b))
+#define ssub64(a, b) select64((a) < (b), 0, (a) - (b))
 
 // Signed saturating arithmetic (clamps to INT_MIN/INT_MAX)
 #define DEFINE_ISADD(SUFFIX, TYPE, UTYPE, SELECT_FUNC, MIN_VAL, MAX_VAL)       \
@@ -289,17 +298,19 @@ DEFINE_POW(i32, int32_t, iselect32)
 DEFINE_POW(i64, int64_t, iselect64)
 
 // Parity and utility bit checks
-// Note: is_even64, is_odd64 omitted - require 64-bit constant (1) not supported by parasol target
 #define is_even8(x) (((x) & 1) == 0)
 #define is_even16(x) (((x) & 1) == 0)
 #define is_even32(x) (((x) & 1) == 0)
+#define is_even64(x) (((x) & 1ULL) == 0)
 
 #define is_odd8(x) (((x) & 1) == 1)
 #define is_odd16(x) (((x) & 1) == 1)
 #define is_odd32(x) (((x) & 1) == 1)
+#define is_odd64(x) (((x) & 1ULL) == 1)
 
 // Bit extraction (returns the nth bit as a boolean)
-// Note: get_bit64 omitted - requires 64-bit shift operation not supported by parasol target
+// Note: get_bit64 omitted - requires 64-bit shift operation not supported by
+// parasol target
 static inline bool get_bit8(uint8_t value, unsigned int n) {
   return ((value >> n) & 0x1);
 }
@@ -375,8 +386,8 @@ static inline bool get_bit32(uint32_t value, unsigned int n) {
 
 // Tree reduction for sum - uses wider accumulator to reduce overflow risk
 #define DEFINE_SUM_ARRAY(NAME, INPUT_TYPE, SUM_TYPE)                           \
-  static inline SUM_TYPE NAME##_array(                                         \
-      const INPUT_TYPE *arr, uint16_t len, SUM_TYPE *scratch) {                \
+  static inline SUM_TYPE NAME##_array(const INPUT_TYPE *arr, uint16_t len,     \
+                                      SUM_TYPE *scratch) {                     \
     for (uint32_t i = 0; i < len; i++) {                                       \
       scratch[i] = (SUM_TYPE)arr[i];                                           \
     }                                                                          \
@@ -505,7 +516,8 @@ GENERATE_ARRAY_OPS_UNSIGNED(32)
 //
 // Choosing accumulator size:
 //   - Known small arrays or bounded sums: use smallest safe accumulator
-//   - Unknown/dynamic array sizes: use next larger accumulator for safety margin
+//   - Unknown/dynamic array sizes: use next larger accumulator for safety
+//   margin
 //   - Critical correctness requirements: use largest accumulator (64-bit)
 //   - Performance-critical with validated bounds: use matching-size accumulator
 //
@@ -513,22 +525,34 @@ GENERATE_ARRAY_OPS_UNSIGNED(32)
 //   Example: sum8_16 safe for 65535/255 = 257 elements of max value
 
 // 8-bit input sum functions
-DEFINE_SUM_ARRAY(sum8_16, uint8_t, uint16_t)   // Up to 257 elements of max value (255)
-DEFINE_SUM_ARRAY(sum8_32, uint8_t, uint32_t)   // Up to 16M elements of max value
-DEFINE_SUM_ARRAY(sum8_64, uint8_t, uint64_t)   // Maximum safety (72+ quadrillion elements)
+DEFINE_SUM_ARRAY(sum8_16, uint8_t,
+                 uint16_t) // Up to 257 elements of max value (255)
+DEFINE_SUM_ARRAY(sum8_32, uint8_t, uint32_t) // Up to 16M elements of max value
+DEFINE_SUM_ARRAY(sum8_64, uint8_t,
+                 uint64_t) // Maximum safety (72+ quadrillion elements)
 
 // 16-bit input sum functions
-DEFINE_SUM_ARRAY(sum16_32, uint16_t, uint32_t) // Up to 65537 elements of max value (65535)
-DEFINE_SUM_ARRAY(sum16_64, uint16_t, uint64_t) // Maximum safety (281+ trillion elements)
+DEFINE_SUM_ARRAY(sum16_32, uint16_t,
+                 uint32_t) // Up to 65537 elements of max value (65535)
+DEFINE_SUM_ARRAY(sum16_64, uint16_t,
+                 uint64_t) // Maximum safety (281+ trillion elements)
 
 // 32-bit input sum functions
-DEFINE_SUM_ARRAY(sum32_64, uint32_t, uint64_t) // Safe default (4+ billion elements of max value)
-DEFINE_SUM_ARRAY(sum32_32, uint32_t, uint32_t) // Performance option (overflow possible, use with care)
+DEFINE_SUM_ARRAY(sum32_64, uint32_t,
+                 uint64_t) // Safe default (4+ billion elements of max value)
+DEFINE_SUM_ARRAY(
+    sum32_32, uint32_t,
+    uint32_t) // Performance option (overflow possible, use with care)
 
-// 64-bit input sum function
-DEFINE_SUM_ARRAY(sum64_64, uint64_t, uint64_t) // Same size (no 128-bit available, overflow possible)
+// 64-bit input sum functions
+DEFINE_SUM_ARRAY(sum64_64, uint64_t,
+                 uint64_t) // Same size (overflow possible, use with care)
+#ifdef __SIZEOF_INT128__
+DEFINE_SUM_ARRAY(sum64_128, uint64_t,
+                 uint128_t) // Safe default (18+ quintillion elements)
+#endif
 
-// Generate 64-bit unsigned functions except sum (sum64 would overflow without 128-bit accumulator)
+// Generate 64-bit unsigned functions
 DEFINE_MIN_ARRAY(64, uint64_t, select64)
 DEFINE_MAX_ARRAY(64, uint64_t, select64)
 DEFINE_COMPARE_SWAP(uint64, uint64_t, select64)
@@ -547,22 +571,33 @@ GENERATE_ARRAY_OPS_SIGNED(32)
 //   Negative: max_safe_elements = abs(MIN_ACCUMULATOR) / abs(MIN_INPUT_VALUE)
 
 // 8-bit input sum functions
-DEFINE_SUM_ARRAY(isum8_16, int8_t, int16_t)   // Up to 257 elements (32767/127, 32768/128)
-DEFINE_SUM_ARRAY(isum8_32, int8_t, int32_t)   // Up to 16M elements of extreme values
-DEFINE_SUM_ARRAY(isum8_64, int8_t, int64_t)   // Maximum safety
+DEFINE_SUM_ARRAY(isum8_16, int8_t,
+                 int16_t) // Up to 257 elements (32767/127, 32768/128)
+DEFINE_SUM_ARRAY(isum8_32, int8_t,
+                 int32_t) // Up to 16M elements of extreme values
+DEFINE_SUM_ARRAY(isum8_64, int8_t, int64_t) // Maximum safety
 
 // 16-bit input sum functions
-DEFINE_SUM_ARRAY(isum16_32, int16_t, int32_t) // Up to 65537 elements of extreme values
+DEFINE_SUM_ARRAY(isum16_32, int16_t,
+                 int32_t) // Up to 65537 elements of extreme values
 DEFINE_SUM_ARRAY(isum16_64, int16_t, int64_t) // Maximum safety
 
 // 32-bit input sum functions
-DEFINE_SUM_ARRAY(isum32_64, int32_t, int64_t) // Safe default (4+ billion elements)
-DEFINE_SUM_ARRAY(isum32_32, int32_t, int32_t) // Performance option (overflow possible, use with care)
+DEFINE_SUM_ARRAY(isum32_64, int32_t,
+                 int64_t) // Safe default (4+ billion elements)
+DEFINE_SUM_ARRAY(
+    isum32_32, int32_t,
+    int32_t) // Performance option (overflow possible, use with care)
 
-// 64-bit input sum function
-DEFINE_SUM_ARRAY(isum64_64, int64_t, int64_t) // Same size (no 128-bit available, overflow possible)
+// 64-bit input sum functions
+DEFINE_SUM_ARRAY(isum64_64, int64_t,
+                 int64_t) // Same size (overflow possible, use with care)
+#ifdef __SIZEOF_INT128__
+DEFINE_SUM_ARRAY(isum64_128, int64_t,
+                 int128_t) // Safe default (18+ quintillion elements)
+#endif
 
-// Generate 64-bit signed functions except sum (isum64 would overflow without 128-bit accumulator)
+// Generate 64-bit signed functions
 DEFINE_MIN_ARRAY_SIGNED(64)
 DEFINE_MAX_ARRAY_SIGNED(64)
 DEFINE_COMPARE_SWAP(int64, int64_t, iselect64)

--- a/license-sunscreen-changes.txt
+++ b/license-sunscreen-changes.txt
@@ -6,6 +6,7 @@ Major Changes
 
 - Add support for the Parasol FHE processor.
 - Add `[[clang::encrypted]]` and `[[clang::fhe_circuit]]` to clang to define what functions should be compiled for the Parasol processor and what arguments to a function are expected to be encrypted.
+- Add 64-bit and 128-bit constant support via constant pools for the Parasol backend.
 
 
 Files changed
@@ -106,6 +107,7 @@ llvm/lib/Target/Parasol/MCTargetDesc/CMakeLists.txt
 llvm/lib/Target/Parasol/MCTargetDesc/LLVMBuild.txt
 llvm/lib/Target/Parasol/MCTargetDesc/ParasolAsmBackend.cpp
 llvm/lib/Target/Parasol/MCTargetDesc/ParasolELFObjectWriter.cpp
+llvm/lib/Target/Parasol/MCTargetDesc/ParasolFixupKinds.h
 llvm/lib/Target/Parasol/MCTargetDesc/ParasolInstPrinter.cpp
 llvm/lib/Target/Parasol/MCTargetDesc/ParasolInstPrinter.h
 llvm/lib/Target/Parasol/MCTargetDesc/ParasolMCAsmInfo.cpp

--- a/license-sunscreen-changes.txt
+++ b/license-sunscreen-changes.txt
@@ -159,6 +159,9 @@ llvm/utils/gn/secondary/llvm/lib/Target/targets.gni
 utils/bazel/llvm_configs/llvm-config.h.cmake
 parasol-tests/.gitignore
 parasol-tests/run_tests.sh
+parasol-tests/test_alignment.c
 parasol-tests/test_array_reductions.c
 parasol-tests/test_array_sort.c
+parasol-tests/test_large_constants.c
+parasol-tests/test_parasol_compilation.c
 parasol-tests/test_utilities.c

--- a/lld/ELF/Arch/Parasol.cpp
+++ b/lld/ELF/Arch/Parasol.cpp
@@ -7,53 +7,105 @@
 
 #include "InputFiles.h"
 #include "Target.h"
+#include "llvm/BinaryFormat/ELF.h"
+#include "llvm/Support/Endian.h"
+#include "llvm/Support/MathExtras.h"
 
 using namespace lld;
 using namespace lld::elf;
+using namespace llvm;
 
 namespace {
+
+// Parasol instruction format constants
+// Instructions are 64 bits. Different relocation types patch different fields.
+constexpr unsigned kLoadAddrOffsetShift = 27;
+constexpr unsigned kLoadAddrOffsetWidth = 32;
+constexpr uint64_t kLoadAddrOffsetMask = ((1ULL << kLoadAddrOffsetWidth) - 1)
+                                         << kLoadAddrOffsetShift;
+
+constexpr unsigned kBranchOffsetShift = 8;
+constexpr unsigned kBranchOffsetWidth = 32;
+constexpr uint64_t kBranchOffsetMask = ((1ULL << kBranchOffsetWidth) - 1)
+                                       << kBranchOffsetShift;
+
+// Pre-computed value mask for relocation patching
+constexpr uint64_t kLoadAddrValueMask = (1ULL << kLoadAddrOffsetWidth) - 1;
+
 class ParasolTargetInfo final : public TargetInfo {
 public:
-    ParasolTargetInfo();
-    RelExpr getRelExpr(RelType type, const Symbol &s,
-        const uint8_t *loc) const override;
-    void relocate(uint8_t *loc, const Relocation &rel,
-        uint64_t val) const override;
+  ParasolTargetInfo();
+  RelExpr getRelExpr(RelType type, const Symbol &s,
+                     const uint8_t *loc) const override;
+  void relocate(uint8_t *loc, const Relocation &rel,
+                uint64_t val) const override;
 };
+
+} // namespace
+
+void ParasolTargetInfo::relocate(uint8_t *loc, const Relocation &rel,
+                                 uint64_t val) const {
+  // Parasol uses little-endian instruction encoding (64-bit instructions)
+  switch (rel.type) {
+  case ELF::R_Parasol_NONE:
+    break;
+  case ELF::R_Parasol_32: {
+    // Parasol instructions are 64-bit. The 32-bit address field is at bit
+    // offset 27. Read current instruction, mask in the value, write back.
+    // Note: Parasol uses 32-bit addressing, so all address relocations
+    // (including those for 64-bit data) use R_Parasol_32.
+    if (val > UINT32_MAX)
+      error(getErrorLocation(loc) + "relocation R_Parasol_32 out of range: " +
+            Twine(val));
+    uint64_t insn = support::endian::read64le(loc);
+    insn = (insn & ~kLoadAddrOffsetMask) |
+           ((val & kLoadAddrValueMask) << kLoadAddrOffsetShift);
+    support::endian::write64le(loc, insn);
+    break;
+  }
+  case ELF::R_Parasol_PC24: {
+    // PC-relative relocation at bit offset 8 for branch instructions.
+    // The field is 32 bits wide to accommodate the signed offset.
+    int64_t signedVal = static_cast<int64_t>(val);
+    if (!isInt<32>(signedVal))
+      error(getErrorLocation(loc) + "relocation R_Parasol_PC24 out of range: " +
+            Twine(signedVal));
+    uint64_t insn = support::endian::read64le(loc);
+    // Use signedVal cast to uint32_t to preserve sign bits in encoding
+    uint32_t encodedOffset = static_cast<uint32_t>(signedVal);
+    insn = (insn & ~kBranchOffsetMask) |
+           (static_cast<uint64_t>(encodedOffset) << kBranchOffsetShift);
+    support::endian::write64le(loc, insn);
+    break;
+  }
+  default:
+    llvm_unreachable("unknown relocation");
+  }
 }
 
-void ParasolTargetInfo::relocate(
-    uint8_t *loc,
-    const Relocation &rel,
-    uint64_t val
-) const {
-    switch (rel.type) {
-    default:
-        llvm_unreachable("unknown relocation");
-    }
-}
-
-RelExpr ParasolTargetInfo::getRelExpr(
-    RelType type,
-    const Symbol &s,
-    const uint8_t *loc
-) const {
-    switch (type) {
-    default:
-        error(getErrorLocation(loc) + "unknown relocation (" + Twine(type) +
-        ") against symbol " + toString(s));
-        return R_NONE;
-    }
+RelExpr ParasolTargetInfo::getRelExpr(RelType type, const Symbol &s,
+                                      const uint8_t *loc) const {
+  switch (type) {
+  case ELF::R_Parasol_NONE:
+    return R_NONE;
+  case ELF::R_Parasol_32:
+    return R_ABS;
+  case ELF::R_Parasol_PC24:
+    return R_PC;
+  default:
+    error(getErrorLocation(loc) + "unknown relocation (" + Twine(type) +
+          ") against symbol " + toString(s));
+    return R_NONE;
+  }
 }
 
 ParasolTargetInfo::ParasolTargetInfo() {
-    pltHeaderSize = 32;
-    pltEntrySize = 16;
-    ipltEntrySize = 16;
+  pltHeaderSize = 32;
+  pltEntrySize = 16;
+  ipltEntrySize = 16;
 }
 
 TargetInfo *elf::getParasolTargetInfo() {
-    static ParasolTargetInfo t;
-
-    return &t;
+  static ParasolTargetInfo t;
+  return &t;
 }

--- a/llvm/lib/Target/Parasol/MCTargetDesc/ParasolAsmBackend.cpp
+++ b/llvm/lib/Target/Parasol/MCTargetDesc/ParasolAsmBackend.cpp
@@ -31,7 +31,7 @@ public:
       : MCAsmBackend(StringRef(T.getName()) == "parasol"
                          ? llvm::endianness::little
                          : llvm::endianness::big),
-        TheTarget(T) {}
+        TheTarget(T), Is64Bit(false) {}
 
   unsigned getNumFixupKinds() const override {
     return Parasol::NumTargetFixupKinds;
@@ -53,6 +53,7 @@ public:
     static const MCFixupKindInfo Infos[Parasol::NumTargetFixupKinds] = {
         {"fixup_br_one_reg_imm", 14, 32, MCFixupKindInfo::FKF_IsPCRel},
         {"fixup_br_imm", 8, 32, MCFixupKindInfo::FKF_IsPCRel},
+        {"fixup_load_addr", 27, 32, 0}, // Offset field for absolute address
     };
 
     if (Kind < FirstTargetFixupKind)
@@ -74,13 +75,10 @@ public:
   bool fixupNeedsRelaxation(const MCFixup &Fixup, uint64_t Value,
                             const MCRelaxableFragment *DF,
                             const MCAsmLayout &Layout) const override {
-    // FIXME.
     llvm_unreachable("fixupNeedsRelaxation() unimplemented");
-    return false;
   }
   void relaxInstruction(MCInst &Inst,
                         const MCSubtargetInfo &STI) const override {
-    // FIXME.
     llvm_unreachable("relaxInstruction() unimplemented");
   }
 
@@ -114,6 +112,14 @@ public:
       return;
 
     auto fixup_info = getFixupKindInfo(Fixup.getKind());
+    // Parasol uses 32-bit addresses/offsets. For PC-relative fixups, the value
+    // may be sign-extended (negative offsets for backward branches). For
+    // absolute fixups, verify no high bits are set.
+    if (!(fixup_info.Flags & MCFixupKindInfo::FKF_IsPCRel)) {
+      assert(
+          (Value >> 32) == 0 &&
+          "Absolute fixup value exceeds 32-bit range - indicates upstream bug");
+    }
     Value = (Value & 0xFFFFFFFF) << fixup_info.TargetOffset;
     if (!Value)
       return; // Doesn't change encoding.

--- a/llvm/lib/Target/Parasol/MCTargetDesc/ParasolELFObjectWriter.cpp
+++ b/llvm/lib/Target/Parasol/MCTargetDesc/ParasolELFObjectWriter.cpp
@@ -5,8 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// #include "MCTargetDesc/ParasolFixupKinds.h"
-// #include "MCTargetDesc/ParasolMCExpr.h"
+#include "MCTargetDesc/ParasolFixupKinds.h"
 #include "MCTargetDesc/ParasolMCTargetDesc.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/MC/MCELFObjectWriter.h"
@@ -46,7 +45,31 @@ unsigned ParasolELFObjectWriter::getRelocType(MCContext &Ctx,
   if (Kind >= FirstLiteralRelocationKind)
     return Kind - FirstLiteralRelocationKind;
 
-  return 0;
+  // Handle Parasol-specific fixups first
+  unsigned FixupKind = static_cast<unsigned>(Kind);
+  if (FixupKind >= FirstTargetFixupKind) {
+    switch (FixupKind) {
+    case Parasol::fixup_br_one_reg_imm:
+    case Parasol::fixup_br_imm:
+      return IsPCRel ? ELF::R_Parasol_PC24 : ELF::R_Parasol_32;
+    case Parasol::fixup_load_addr:
+      return ELF::R_Parasol_32; // Absolute 32-bit address for constant pool
+    default:
+      llvm_unreachable("Unhandled Parasol fixup kind");
+    }
+  }
+
+  // Map standard fixups to ELF relocation types
+  switch (Kind) {
+  case FK_Data_1:
+  case FK_Data_2:
+  case FK_Data_4:
+    return ELF::R_Parasol_32;
+  case FK_Data_8:
+    return ELF::R_Parasol_32; // Use 32-bit relocation for addresses
+  default:
+    llvm_unreachable("Unhandled fixup kind in getRelocType");
+  }
 }
 
 bool ParasolELFObjectWriter::needsRelocateWithSymbol(const MCValue &,

--- a/llvm/lib/Target/Parasol/MCTargetDesc/ParasolFixupKinds.h
+++ b/llvm/lib/Target/Parasol/MCTargetDesc/ParasolFixupKinds.h
@@ -7,6 +7,7 @@ namespace llvm::Parasol {
 enum Fixups {
   fixup_br_one_reg_imm = FirstTargetFixupKind,
   fixup_br_imm,
+  fixup_load_addr,
 
   // Marker
   LastTargetFixupKind,

--- a/llvm/lib/Target/Parasol/MCTargetDesc/ParasolMCCodeEmitter.cpp
+++ b/llvm/lib/Target/Parasol/MCTargetDesc/ParasolMCCodeEmitter.cpp
@@ -92,14 +92,8 @@ ParasolMCCodeEmitter::getMachineOpValue(const MCInst &MI, const MCOperand &MO,
     return MO.getImm();
 
   assert(MO.isExpr());
-  // SUNSCREEN TODO: Reenable?
-  // if (const ParasolMCExpr *SExpr = dyn_cast<ParasolMCExpr>(Expr)) {
-  //   MCFixupKind Kind = (MCFixupKind)SExpr->getFixupKind();
-  //   Fixups.push_back(MCFixup::create(0, Expr, Kind));
-  //   return 0;
-  // }
 
-  auto Expr = MO.getExpr();
+  const MCExpr *Expr = MO.getExpr();
 
   switch (MI.getOpcode()) {
   case Parasol::BRZ:
@@ -110,6 +104,10 @@ ParasolMCCodeEmitter::getMachineOpValue(const MCInst &MI, const MCOperand &MO,
   case Parasol::BR:
     Fixups.push_back(
         MCFixup::create(0, Expr, MCFixupKind(Parasol::fixup_br_imm)));
+    break;
+  case Parasol::LOAD:
+    Fixups.push_back(
+        MCFixup::create(0, Expr, MCFixupKind(Parasol::fixup_load_addr)));
     break;
   default:
     llvm_unreachable("Opcode should not need fixups");
@@ -122,10 +120,9 @@ unsigned
 ParasolMCCodeEmitter::getCallTargetOpValue(const MCInst &MI, unsigned OpNo,
                                            SmallVectorImpl<MCFixup> &Fixups,
                                            const MCSubtargetInfo &STI) const {
-  const MCOperand &MO = MI.getOperand(OpNo);
-  const MCExpr *Expr = MO.getExpr();
-
-  return 0;
+  // TODO: Implement call target encoding when call instructions are supported
+  llvm_unreachable("Call instructions not yet implemented - "
+                   "instruction selector incorrectly emitted a call");
 }
 
 unsigned
@@ -134,7 +131,7 @@ ParasolMCCodeEmitter::getBranchTargetOpValue(const MCInst &MI, unsigned OpNo,
                                              const MCSubtargetInfo &STI) const {
   const MCOperand &MO = MI.getOperand(OpNo);
   if (MO.isReg() || MO.isImm())
-    getMachineOpValue(MI, MO, Fixups, STI);
+    return getMachineOpValue(MI, MO, Fixups, STI);
 
   return 0;
 }

--- a/llvm/lib/Target/Parasol/ParasolAsmPrinter.cpp
+++ b/llvm/lib/Target/Parasol/ParasolAsmPrinter.cpp
@@ -21,6 +21,7 @@
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/ErrorHandling.h"
 
 using namespace llvm;
 
@@ -64,7 +65,61 @@ void ParasolAsmPrinter::EmitToStreamer(MCStreamer &S, const MCInst &Inst) {
   AsmPrinter::EmitToStreamer(*OutStreamer, Inst);
 }
 
+// Bit sizes for constant pool load instructions
+static constexpr unsigned kLoadSize64 = 64;
+static constexpr unsigned kLoadSize128 = 128;
+
 void ParasolAsmPrinter::emitInstruction(const MachineInstr *MI) {
+  // Handle LoadConstantPool pseudo-instructions
+  unsigned Opc = MI->getOpcode();
+  if (Opc == Parasol::LoadConstantPool64 ||
+      Opc == Parasol::LoadConstantPool128) {
+    // These pseudo-instructions need to be expanded to a sequence:
+    // 1. LoadImmediate32 dst, 0  - Load 0 into dst (to use as base address)
+    //    Note: Parasol does not have a dedicated zero register, so we must
+    //    explicitly load zero before using it as a base address.
+    // 2. LOAD dst, dst, size, symbol - Load from (0 + symbol) into dst
+    //    The symbol offset becomes the effective address via relocation.
+    //
+    // We use dst as both the temporary for 0 and the final destination.
+    // This works because LOAD reads addr before writing to dst.
+
+    const unsigned DstReg = MI->getOperand(0).getReg();
+
+    // Emit: LoadImmediate32 dst, 0
+    MCInst LDI;
+    LDI.setOpcode(Parasol::LoadImmediate32);
+    LDI.addOperand(MCOperand::createReg(DstReg));
+    LDI.addOperand(MCOperand::createImm(0));
+    EmitToStreamer(*OutStreamer, LDI);
+
+    // Emit: LOAD dst, dst, size, symbol
+    MCInst LoadInst;
+    LoadInst.setOpcode(Parasol::LOAD);
+
+    // Operand 0: destination register (val)
+    LoadInst.addOperand(MCOperand::createReg(DstReg));
+
+    // Operand 1: address register (addr) - use dst which now contains 0
+    LoadInst.addOperand(MCOperand::createReg(DstReg));
+
+    // Operand 2: size (in bits)
+    const unsigned Size =
+        (Opc == Parasol::LoadConstantPool64) ? kLoadSize64 : kLoadSize128;
+    LoadInst.addOperand(MCOperand::createImm(Size));
+
+    // Operand 3: offset - constant pool symbol (this will create a fixup)
+    const MachineOperand &CPOp = MI->getOperand(1);
+    assert(CPOp.isCPI() && "Expected constant pool index operand");
+    unsigned CPIdx = CPOp.getIndex();
+    MCSymbol *CPSym = GetCPISymbol(CPIdx);
+    const MCExpr *Expr = MCSymbolRefExpr::create(CPSym, OutContext);
+    LoadInst.addOperand(MCOperand::createExpr(Expr));
+
+    EmitToStreamer(*OutStreamer, LoadInst);
+    return;
+  }
+
   // Do any auto-generated pseudo lowerings.
   if (emitPseudoExpansionLowering(*OutStreamer, MI))
     return;

--- a/llvm/lib/Target/Parasol/ParasolISelDAGToDAG.cpp
+++ b/llvm/lib/Target/Parasol/ParasolISelDAGToDAG.cpp
@@ -10,9 +10,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "ParasolISelDAGToDAG.h"
+#include "ParasolISelLowering.h"
 #include "ParasolSubtarget.h"
+#include "llvm/CodeGen/MachineConstantPool.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/SelectionDAGISel.h"
+#include "llvm/CodeGen/SelectionDAGNodes.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/DerivedTypes.h"
 
 using namespace llvm;
 
@@ -33,6 +38,28 @@ void ParasolDAGToDAGISel::Select(SDNode *Node) {
     LLVM_DEBUG(errs() << "== "; Node->dump(CurDAG); errs() << "\n");
     Node->setNodeId(-1);
     return;
+  }
+
+  // Custom selection for Wrapper nodes (constant pools, globals, etc.)
+  if (Node->getOpcode() == ParasolISD::Wrapper) {
+    SDValue Op = Node->getOperand(0);
+    EVT VT = Node->getValueType(0);
+
+    // Handle constant pool wrappers
+    if (const ConstantPoolSDNode *CN = dyn_cast<ConstantPoolSDNode>(Op)) {
+      assert((VT == MVT::i64 || VT == MVT::i128) &&
+             "Unexpected type for constant pool wrapper");
+      unsigned Opcode = (VT == MVT::i64) ? Parasol::LoadConstantPool64
+                                         : Parasol::LoadConstantPool128;
+      LLVM_DEBUG(dbgs() << "Selecting constant pool load for "
+                        << (VT == MVT::i64 ? "i64" : "i128") << "\n");
+
+      SDValue CPIdx = CurDAG->getTargetConstantPool(
+          CN->getConstVal(), MVT::i32, CN->getAlign(), CN->getOffset());
+      SDNode *ResNode = CurDAG->getMachineNode(Opcode, dl, VT, CPIdx);
+      ReplaceNode(Node, ResNode);
+      return;
+    }
   }
 
   // Select the default instruction

--- a/llvm/lib/Target/Parasol/ParasolISelLowering.cpp
+++ b/llvm/lib/Target/Parasol/ParasolISelLowering.cpp
@@ -15,6 +15,7 @@
 #include "ParasolTargetMachine.h"
 #include "llvm/CodeGen/CallingConvLower.h"
 #include "llvm/CodeGen/ISDOpcodes.h"
+#include "llvm/CodeGen/MachineConstantPool.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
@@ -76,6 +77,10 @@ ParasolTargetLowering::ParasolTargetLowering(const TargetMachine &TM,
   setOperationAction(ISD::BlockAddress, MVT::i32, Custom);
   setOperationAction(ISD::ConstantPool, MVT::i32, Custom);
 
+  // Custom lowering for large constants via constant pools
+  setOperationAction(ISD::Constant, MVT::i64, Custom);
+  setOperationAction(ISD::Constant, MVT::i128, Custom);
+
   // Parasol has no select or setcc: expand to SELECT_CC.
   setOperationAction(
       {ISD::SELECT_CC},
@@ -121,8 +126,10 @@ const char *ParasolTargetLowering::getTargetNodeName(unsigned Opcode) const {
     return "ParasolISD::Ret";
   case ParasolISD::BR_CC:
     return "ParasolISD::BR_CC";
+  case ParasolISD::Wrapper:
+    return "ParasolISD::Wrapper";
   default:
-    return NULL;
+    return nullptr;
   }
 }
 
@@ -178,7 +185,7 @@ void ParasolTargetLowering::analyzeInputArgs(
                   ArgFlags, CCInfo, IsRet, ArgTy, *this)) {
       LLVM_DEBUG(dbgs() << "InputArg #" << i << " has unhandled type " << ArgVT
                         << '\n');
-      llvm_unreachable(nullptr);
+      llvm_unreachable("Unhandled argument type");
     }
   }
 }
@@ -282,16 +289,10 @@ SDValue ParasolTargetLowering::LowerFormalArguments(
   }
 
   MachineFunction &MF = DAG.getMachineFunction();
-  Function &F = MF.getFunction();
-  MachineFrameInfo &MFI = MF.getFrameInfo();
 
   // Assign locations to all of the incoming arguments.
   SmallVector<CCValAssign, 16> ArgLocs;
   CCState CCInfo(CallConv, isVarArg, MF, ArgLocs, *DAG.getContext());
-
-  SmallVector<SDValue, 16> ArgValues;
-  SDValue ArgValue;
-  Function::const_arg_iterator CurOrigArg = MF.getFunction().arg_begin();
 
   analyzeInputArgs(MF, CCInfo, Ins, false);
 
@@ -397,8 +398,9 @@ ParasolTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
 /// and then confiscate the rest of the parameter registers to insure
 /// this.
 
-void ParasolTargetLowering::HandleByVal(CCState *State, unsigned &Size,
-                                        Align align) const {}
+void ParasolTargetLowering::HandleByVal(CCState * /*State*/,
+                                        unsigned & /*Size*/,
+                                        Align /*Alignment*/) const {}
 
 SDValue
 ParasolTargetLowering::LowerReturn(SDValue Chain, CallingConv::ID CallConv,
@@ -418,7 +420,7 @@ ParasolTargetLowering::LowerReturn(SDValue Chain, CallingConv::ID CallConv,
     int64_t Size = Val.getValueType().getStoreSize();
 
     // Align our offset to the next allowable address.
-    Offset += (Size - Offset % Size) % Size;
+    Offset = alignTo(Offset, Align(Size));
 
     SDValue ReturnPtr = DAG.getRegister(Parasol::X10, MVT::i32);
     SDValue OffsetNode = DAG.getConstant(Offset, DL, MVT::i32);
@@ -463,7 +465,47 @@ SDValue ParasolTargetLowering::LowerGlobalAddress(SDValue Op,
 
 SDValue ParasolTargetLowering::LowerConstantPool(SDValue Op,
                                                  SelectionDAG &DAG) const {
-  llvm_unreachable("Unsupported constant pool");
+  EVT PtrVT = Op.getValueType();
+  SDLoc DL(Op);
+  ConstantPoolSDNode *CP = cast<ConstantPoolSDNode>(Op);
+
+  SDValue Res;
+  if (CP->isMachineConstantPoolEntry())
+    Res =
+        DAG.getTargetConstantPool(CP->getMachineCPVal(), PtrVT, CP->getAlign());
+  else
+    Res = DAG.getTargetConstantPool(CP->getConstVal(), PtrVT, CP->getAlign());
+
+  return DAG.getNode(ParasolISD::Wrapper, DL, PtrVT, Res);
+}
+
+SDValue ParasolTargetLowering::LowerConstant(SDValue Op,
+                                             SelectionDAG &DAG) const {
+  const ConstantSDNode *CN = cast<ConstantSDNode>(Op);
+  EVT VT = Op.getValueType();
+  SDLoc DL(Op);
+
+  assert((VT == MVT::i64 || VT == MVT::i128) &&
+         "LowerConstant called for unsupported type");
+
+  // Create constant pool entry for large constants.
+  // All i64/i128 constants (including zero) are stored in the constant pool.
+  // The AsmPrinter expands LoadConstantPool pseudo-instructions to:
+  //   LDI dst, 0                    ; Load zero as base address
+  //   LOAD dst, dst, size, symbol   ; Load constant from pool
+  Type *Ty = Type::getIntNTy(*DAG.getContext(), VT.getSizeInBits());
+  const Constant *C = ConstantInt::get(Ty, CN->getAPIntValue());
+
+  // Use natural alignment for constant pool entries to ensure efficient access:
+  // 8 bytes for i64 (64 bits), 16 bytes for i128 (128 bits)
+  Align RequiredAlign = (VT == MVT::i128) ? Align(16) : Align(8);
+
+  LLVM_DEBUG(dbgs() << "Creating constant pool entry for "
+                    << (VT == MVT::i128 ? "i128" : "i64")
+                    << " constant: " << CN->getAPIntValue() << "\n");
+
+  SDValue CP = DAG.getTargetConstantPool(C, MVT::i32, RequiredAlign);
+  return DAG.getNode(ParasolISD::Wrapper, DL, VT, CP);
 }
 
 SDValue ParasolTargetLowering::LowerBlockAddress(SDValue Op,
@@ -485,6 +527,8 @@ SDValue ParasolTargetLowering::LowerOperation(SDValue Op,
     return LowerBlockAddress(Op, DAG);
   case ISD::ConstantPool:
     return LowerConstantPool(Op, DAG);
+  case ISD::Constant:
+    return LowerConstant(Op, DAG);
   case ISD::RETURNADDR:
     return LowerRETURNADDR(Op, DAG);
   default:

--- a/llvm/lib/Target/Parasol/ParasolISelLowering.h
+++ b/llvm/lib/Target/Parasol/ParasolISelLowering.h
@@ -38,6 +38,10 @@ enum NodeType {
   BR_CC,
 
   STOREBASEOFFSET,
+
+  // Wrapper for addresses of global values, constant pools, etc.
+  Wrapper,
+
   // Return
   Ret,
 };
@@ -74,6 +78,7 @@ private:
   SDValue LowerGlobalAddress(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerBlockAddress(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerConstantPool(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerConstant(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerRETURNADDR(SDValue Op, SelectionDAG &DAG) const;
 
   using RegsToPassVector = SmallVector<std::pair<unsigned, SDValue>, 8>;

--- a/llvm/lib/Target/Parasol/ParasolInstrInfo.td
+++ b/llvm/lib/Target/Parasol/ParasolInstrInfo.td
@@ -35,6 +35,9 @@ def callseq_start : SDNode<"ISD::CALLSEQ_START", SDT_CallSeqStart,
 def callseq_end   : SDNode<"ISD::CALLSEQ_END", SDT_CallSeqEnd,
                            [SDNPHasChain, SDNPOptInGlue, SDNPOutGlue]>;
 
+// Wrapper node for constant pool addresses
+def parasol_wrapper : SDNode<"ParasolISD::Wrapper", SDTIntUnaryOp>;
+
 include "ParasolInstrFormats.td"
 
 let isCodeGenOnly = 1, Defs = [X2], Uses = [X2] in {
@@ -56,6 +59,12 @@ def LoadImmediate8 : ParasolLoadImm<Parasolimm8, i8>;
 def LoadImmediate16 : ParasolLoadImm<Parasolimm16, i16>;
 def LoadImmediate32 : ParasolLoadImm<Parasolimm32, i32>;
 
+// Pseudo-instructions for loading from constant pools
+// Note: These are selected manually in ISelDAGToDAG, not via TableGen patterns
+let isPseudo = 1, isCodeGenOnly = 1 in {
+def LoadConstantPool64 : Pseudo<(outs IR:$dst), (ins i32imm:$cpidx), []>;
+def LoadConstantPool128 : Pseudo<(outs IR:$dst), (ins i32imm:$cpidx), []>;
+}
 
 //===----------------------------------------------------------------------===//
 // Load/Store Instructions

--- a/parasol-tests/test_alignment.c
+++ b/parasol-tests/test_alignment.c
@@ -1,3 +1,8 @@
+// test_alignment.c - Alignment verification tests for i128 constants
+//
+// Created by Sunscreen under the AGPLv3 license; see the README at the
+// repository root for more information
+
 #include <stdint.h>
 
 // Alignment verification tests for i128 constants

--- a/parasol-tests/test_alignment.c
+++ b/parasol-tests/test_alignment.c
@@ -1,0 +1,88 @@
+#include <stdint.h>
+
+// Alignment verification tests for i128 constants
+// This file tests whether Parasol ISA requires strict 16-byte alignment for i128
+// or if 8-byte alignment is sufficient
+
+#ifdef __SIZEOF_INT128__
+
+// Test with compiler-default alignment (should use current implementation: 16 bytes)
+__uint128_t test_default_align(__uint128_t a) {
+    __uint128_t c = ((__uint128_t)0x1122334455667788ULL << 64 | 0x99AABBCCDDEEFF00ULL);
+    return a + c;
+}
+
+// Test with explicit 1-byte alignment (stress test)
+__attribute__((aligned(1)))
+static const __uint128_t const_align_1 = ((__uint128_t)0x1122334455667788ULL << 64 | 0x99AABBCCDDEEFF00ULL);
+
+__uint128_t test_align_1(__uint128_t a) {
+    return a + const_align_1;
+}
+
+// Test with explicit 4-byte alignment
+__attribute__((aligned(4)))
+static const __uint128_t const_align_4 = ((__uint128_t)0x1122334455667788ULL << 64 | 0x99AABBCCDDEEFF00ULL);
+
+__uint128_t test_align_4(__uint128_t a) {
+    return a + const_align_4;
+}
+
+// Test with explicit 8-byte alignment
+__attribute__((aligned(8)))
+static const __uint128_t const_align_8 = ((__uint128_t)0x1122334455667788ULL << 64 | 0x99AABBCCDDEEFF00ULL);
+
+__uint128_t test_align_8(__uint128_t a) {
+    return a + const_align_8;
+}
+
+// Test with explicit 16-byte alignment
+__attribute__((aligned(16)))
+static const __uint128_t const_align_16 = ((__uint128_t)0x1122334455667788ULL << 64 | 0x99AABBCCDDEEFF00ULL);
+
+__uint128_t test_align_16(__uint128_t a) {
+    return a + const_align_16;
+}
+
+// Test with explicit 32-byte alignment (over-aligned)
+__attribute__((aligned(32)))
+static const __uint128_t const_align_32 = ((__uint128_t)0x1122334455667788ULL << 64 | 0x99AABBCCDDEEFF00ULL);
+
+__uint128_t test_align_32(__uint128_t a) {
+    return a + const_align_32;
+}
+
+#endif // __SIZEOF_INT128__
+
+// i64 alignment tests for comparison
+uint64_t test_i64_default(uint64_t a) {
+    return a + 0x123456789ABCDEF0ULL;
+}
+
+__attribute__((aligned(1)))
+static const uint64_t const64_align_1 = 0x123456789ABCDEF0ULL;
+
+uint64_t test_i64_align_1(uint64_t a) {
+    return a + const64_align_1;
+}
+
+__attribute__((aligned(4)))
+static const uint64_t const64_align_4 = 0x123456789ABCDEF0ULL;
+
+uint64_t test_i64_align_4(uint64_t a) {
+    return a + const64_align_4;
+}
+
+__attribute__((aligned(8)))
+static const uint64_t const64_align_8 = 0x123456789ABCDEF0ULL;
+
+uint64_t test_i64_align_8(uint64_t a) {
+    return a + const64_align_8;
+}
+
+__attribute__((aligned(16)))
+static const uint64_t const64_align_16 = 0x123456789ABCDEF0ULL;
+
+uint64_t test_i64_align_16(uint64_t a) {
+    return a + const64_align_16;
+}

--- a/parasol-tests/test_large_constants.c
+++ b/parasol-tests/test_large_constants.c
@@ -1,3 +1,8 @@
+// test_large_constants.c - Tests for 64-bit and 128-bit constant generation
+//
+// Created by Sunscreen under the AGPLv3 license; see the README at the
+// repository root for more information
+
 #include <stdint.h>
 
 // Test basic 64-bit constant usage

--- a/parasol-tests/test_large_constants.c
+++ b/parasol-tests/test_large_constants.c
@@ -1,0 +1,79 @@
+#include <stdint.h>
+
+// Test basic 64-bit constant usage
+uint64_t test_64bit_constant(uint64_t a) {
+    return a + 0x123456789ABCDEF0ULL;
+}
+
+// Test with zero
+uint64_t test_zero(uint64_t a) {
+    return a + 0ULL;
+}
+
+// Test with small value that fits in 32 bits
+uint64_t test_small(uint64_t a) {
+    return a + 42ULL;
+}
+
+// Test with max value
+uint64_t test_max(uint64_t a) {
+    return a + 0xFFFFFFFFFFFFFFFFULL;
+}
+
+// Test with value requiring only high bits
+uint64_t test_high_only(uint64_t a) {
+    return a + 0x100000000ULL;
+}
+
+// 128-bit constant tests
+#ifdef __SIZEOF_INT128__
+
+// Test basic 128-bit constant
+__uint128_t test_128bit_constant(__uint128_t a) {
+    return a + ((__uint128_t)0x123456789ABCDEF0ULL << 64 | 0xFEDCBA9876543210ULL);
+}
+
+// Test 128-bit zero (should optimize to X0 register)
+__uint128_t test_128bit_zero(__uint128_t a) {
+    return a + 0;
+}
+
+// Test 128-bit max value
+__uint128_t test_128bit_max(__uint128_t a) {
+    __uint128_t max = ~((__uint128_t)0);
+    return a + max;
+}
+
+// Test 128-bit high 64 bits only
+__uint128_t test_128bit_high_only(__uint128_t a) {
+    return a + ((__uint128_t)1 << 64);
+}
+
+// Test 128-bit low 64 bits only
+__uint128_t test_128bit_low_only(__uint128_t a) {
+    return a + 0xFFFFFFFFFFFFFFFFULL;
+}
+
+// Test 128-bit alternating bit pattern
+__uint128_t test_128bit_alternating(__uint128_t a) {
+    return a + ((__uint128_t)0xAAAAAAAAAAAAAAAAULL << 64 | 0x5555555555555555ULL);
+}
+
+// Test 128-bit small constant
+__uint128_t test_128bit_small(__uint128_t a) {
+    return a + 42;
+}
+
+// Test 128-bit power of two
+__uint128_t test_128bit_power_of_two(__uint128_t a) {
+    return a + ((__uint128_t)1 << 100);
+}
+
+// Test multiple 128-bit constants in one function (constant pool merging)
+__uint128_t test_128bit_multiple(__uint128_t a, __uint128_t b) {
+    __uint128_t c1 = ((__uint128_t)0x1111111111111111ULL << 64 | 0x2222222222222222ULL);
+    __uint128_t c2 = ((__uint128_t)0x3333333333333333ULL << 64 | 0x4444444444444444ULL);
+    return a + c1 + b + c2;
+}
+
+#endif // __SIZEOF_INT128__

--- a/parasol-tests/test_parasol_compilation.c
+++ b/parasol-tests/test_parasol_compilation.c
@@ -1,9 +1,12 @@
-// Test file to force instantiation of all parasol.h functions for parasol target
-// This ensures the compiler actually compiles each function rather than
-// optimizing them away with -O2
+// test_parasol_compilation.c - Force instantiation of all parasol.h functions
 //
-// This file should compile successfully for the parasol target. If compilation
-// fails, it indicates functions that use unsupported instructions.
+// Created by Sunscreen under the AGPLv3 license; see the README at the
+// repository root for more information
+//
+// This file forces the compiler to compile each function rather than
+// optimizing them away with -O2. This file should compile successfully for
+// the parasol target. If compilation fails, it indicates functions that use
+// unsupported instructions.
 
 #include "../clang/lib/Headers/parasol.h"
 

--- a/parasol-tests/test_parasol_compilation.c
+++ b/parasol-tests/test_parasol_compilation.c
@@ -29,18 +29,22 @@ void *saturating_functions[] = {
     (void *)isadd8,
     (void *)isadd16,
     (void *)isadd32,
+    (void *)isadd64,
     (void *)issub8,
     (void *)issub16,
     (void *)issub32,
+    (void *)issub64,
 };
 
 void *pow_functions[] = {
     (void *)pow8,
     (void *)pow16,
     (void *)pow32,
+    (void *)pow64,
     (void *)powi8,
     (void *)powi16,
     (void *)powi32,
+    (void *)powi64,
 };
 
 void *get_bit_functions[] = {
@@ -81,6 +85,9 @@ void *sum_array_functions[] = {
     (void *)sum32_64_array,
     (void *)sum32_32_array,
     (void *)sum64_64_array,
+#ifdef __SIZEOF_INT128__
+    (void *)sum64_128_array,
+#endif
     // Signed sum functions with various accumulator sizes
     (void *)isum8_16_array,
     (void *)isum8_32_array,
@@ -90,6 +97,9 @@ void *sum_array_functions[] = {
     (void *)isum32_64_array,
     (void *)isum32_32_array,
     (void *)isum64_64_array,
+#ifdef __SIZEOF_INT128__
+    (void *)isum64_128_array,
+#endif
 };
 
 void *compare_swap_functions[] = {
@@ -187,32 +197,40 @@ uint32_t test_macros_uint32(uint32_t a, uint32_t b, uint32_t c) {
     return result;
 }
 
-// Note: 64-bit unsigned macro tests (abs64, avg64, sadd64, ssub64, is_even64,
-// is_odd64) removed due to parasol target limitations:
-// - abs64, avg64: use 64-bit shift operations (>> 1, >> 63)
-// - sadd64, ssub64, is_even64, is_odd64: use 64-bit constants
+// Note: 64-bit unsigned macro tests for abs64, avg64 still removed due to
+// parasol target limitations (use 64-bit shift operations >> 1, >> 63).
 //
-// 64-bit macros that DO work are tested below (using 32-bit init parameter
-// to avoid generating 64-bit constants):
-// - Unsigned: min64, max64, clamp64, absdiff64, cswap64
-// - Signed: imin64, imax64, iclamp64, icswap64
-// - Omitted: sign64 (generates 64-bit constant -1), iabsdiff64 (generates >> 63 shift)
+// 64-bit macros that work:
+// - Unsigned: min64, max64, clamp64, absdiff64, cswap64, sadd64, ssub64, is_even64, is_odd64
+// - Signed: imin64, imax64, iclamp64, icswap64, sign64
+// - Omitted: abs64, avg64 (64-bit shifts), iabsdiff64 (generates >> 63 shift)
 
-uint64_t test_macros_uint64(uint64_t a, uint64_t b, uint64_t c, uint32_t init) {
-    uint64_t result = (uint64_t)init;
+uint64_t test_macros_uint64(uint64_t a, uint64_t b, uint64_t c) {
+    uint64_t result = 0;
     result += min64(a, b);
     result += max64(a, b);
     result += clamp64(a, b, c);
     result += absdiff64(a, b);
+    result += sadd64(a, b);
+    result += ssub64(a, b);
+
+    // Test parity checks
+    if (is_even64(a)) {
+        result += 1;
+    }
+    if (is_odd64(a)) {
+        result += 1;
+    }
+
     return result;
 }
 
-int64_t test_macros_int64(int64_t a, int64_t b, int64_t c, int32_t init) {
-    int64_t result = (int64_t)init;
+int64_t test_macros_int64(int64_t a, int64_t b, int64_t c) {
+    int64_t result = 0;
     result += imin64(a, b);
     result += imax64(a, b);
     result += iclamp64(a, b, c);
-    // sign64 omitted - generates 64-bit constant (-1)
+    result += sign64(a);
     // iabsdiff64 omitted - generates 64-bit shift (>> 63) during optimization
     return result;
 }
@@ -288,11 +306,11 @@ int main(void) {
     test_macros_uint8(1, 2, 3);
     test_macros_uint16(1, 2, 3);
     test_macros_uint32(1, 2, 3);
-    test_macros_uint64(1, 2, 3, 0);
+    test_macros_uint64(1, 2, 3);
     test_macros_int8(1, 2, 3);
     test_macros_int16(1, 2, 3);
     test_macros_int32(1, 2, 3);
-    test_macros_int64(1, 2, 3, 0);
+    test_macros_int64(1, 2, 3);
     test_cswap();
 
     return 0;

--- a/parasol-tests/test_utilities.c
+++ b/parasol-tests/test_utilities.c
@@ -102,8 +102,18 @@ void test_sign(void) {
   TEST("sign8(-128) min", sign8(-128) == -1);
 
   TEST("sign16(0)", sign16(0) == 0);
+  TEST("sign16(32767) max", sign16(32767) == 1);
+  TEST("sign16(-32768) min", sign16(-32768) == -1);
+
   TEST("sign32(0)", sign32(0) == 0);
-  // sign64 omitted - generates 64-bit constant (-1) not supported by parasol target
+  TEST("sign32(INT32_MAX) max", sign32(2147483647) == 1);
+  TEST("sign32(INT32_MIN) min", sign32(-2147483647 - 1) == -1);
+
+  TEST("sign64(0)", sign64(0) == 0);
+  TEST("sign64(INT64_MAX) max", sign64(9223372036854775807LL) == 1);
+  TEST("sign64(INT64_MIN) min", sign64(-9223372036854775807LL - 1) == -1);
+  TEST("sign64(42) positive", sign64(42) == 1);
+  TEST("sign64(-42) negative", sign64(-42) == -1);
 }
 
 void test_absdiff(void) {
@@ -118,12 +128,43 @@ void test_absdiff(void) {
 }
 
 void test_saturating_add(void) {
+  // 8-bit unsigned
   TEST("sadd8(0, 0)", sadd8(0, 0) == 0);
   TEST("sadd8(255, 0) boundary", sadd8(255, 0) == 255);
   TEST("sadd8(255, 1) overflow", sadd8(255, 1) == 255);
   TEST("sadd8(200, 100) overflow", sadd8(200, 100) == 255);
   TEST("sadd8(100, 100) no overflow", sadd8(100, 100) == 200);
 
+  // 16-bit unsigned
+  TEST("sadd16(0, 0)", sadd16(0, 0) == 0);
+  TEST("sadd16(65535, 0) boundary", sadd16(65535, 0) == 65535);
+  TEST("sadd16(65535, 1) overflow", sadd16(65535, 1) == 65535);
+  TEST("sadd16(60000, 10000) overflow", sadd16(60000, 10000) == 65535);
+  TEST("sadd16(30000, 30000) no overflow", sadd16(30000, 30000) == 60000);
+
+  // 32-bit unsigned
+  TEST("sadd32(0, 0)", sadd32(0, 0) == 0);
+  TEST("sadd32(0xFFFFFFFF, 0) boundary", sadd32(0xFFFFFFFFU, 0) == 0xFFFFFFFFU);
+  TEST("sadd32(0xFFFFFFFF, 1) overflow", sadd32(0xFFFFFFFFU, 1) == 0xFFFFFFFFU);
+  TEST("sadd32(0xF0000000, 0x20000000) overflow",
+       sadd32(0xF0000000U, 0x20000000U) == 0xFFFFFFFFU);
+  TEST("sadd32(0x40000000, 0x40000000) no overflow",
+       sadd32(0x40000000U, 0x40000000U) == 0x80000000U);
+
+  // 64-bit unsigned
+  TEST("sadd64(0, 0)", sadd64(0, 0) == 0);
+  TEST("sadd64(0xFFFFFFFFFFFFFFFF, 0) boundary",
+       sadd64(0xFFFFFFFFFFFFFFFFULL, 0) == 0xFFFFFFFFFFFFFFFFULL);
+  TEST("sadd64(0xFFFFFFFFFFFFFFFF, 1) overflow",
+       sadd64(0xFFFFFFFFFFFFFFFFULL, 1) == 0xFFFFFFFFFFFFFFFFULL);
+  TEST("sadd64(0xF000000000000000, 0x2000000000000000) overflow",
+       sadd64(0xF000000000000000ULL, 0x2000000000000000ULL) ==
+           0xFFFFFFFFFFFFFFFFULL);
+  TEST("sadd64(0x4000000000000000, 0x4000000000000000) no overflow",
+       sadd64(0x4000000000000000ULL, 0x4000000000000000ULL) ==
+           0x8000000000000000ULL);
+
+  // 8-bit signed
   TEST("isadd8(0, 0)", isadd8(0, 0) == 0);
   TEST("isadd8(127, 0) boundary", isadd8(127, 0) == 127);
   TEST("isadd8(127, 1) pos overflow", isadd8(127, 1) == 127);
@@ -131,21 +172,114 @@ void test_saturating_add(void) {
   TEST("isadd8(-128, -1) neg overflow", isadd8(-128, -1) == -128);
   TEST("isadd8(-100, -50) neg overflow", isadd8(-100, -50) == -128);
   TEST("isadd8(50, 50) no overflow", isadd8(50, 50) == 100);
+
+  // 16-bit signed
+  TEST("isadd16(0, 0)", isadd16(0, 0) == 0);
+  TEST("isadd16(32767, 0) boundary", isadd16(32767, 0) == 32767);
+  TEST("isadd16(32767, 1) pos overflow", isadd16(32767, 1) == 32767);
+  TEST("isadd16(20000, 20000) pos overflow", isadd16(20000, 20000) == 32767);
+  TEST("isadd16(-32768, -1) neg overflow", isadd16(-32768, -1) == -32768);
+  TEST("isadd16(-20000, -20000) neg overflow",
+       isadd16(-20000, -20000) == -32768);
+  TEST("isadd16(10000, 10000) no overflow", isadd16(10000, 10000) == 20000);
+
+  // 32-bit signed
+  TEST("isadd32(0, 0)", isadd32(0, 0) == 0);
+  TEST("isadd32(INT32_MAX, 0) boundary", isadd32(2147483647, 0) == 2147483647);
+  TEST("isadd32(INT32_MAX, 1) pos overflow", isadd32(2147483647, 1) == 2147483647);
+  TEST("isadd32(2000000000, 200000000) pos overflow",
+       isadd32(2000000000, 200000000) == 2147483647);
+  TEST("isadd32(INT32_MIN, -1) neg overflow",
+       isadd32(-2147483647 - 1, -1) == -2147483647 - 1);
+  TEST("isadd32(-2000000000, -200000000) neg overflow",
+       isadd32(-2000000000, -200000000) == -2147483647 - 1);
+  TEST("isadd32(1000000000, 1000000000) no overflow",
+       isadd32(1000000000, 1000000000) == 2000000000);
+
+  // 64-bit signed
+  TEST("isadd64(0, 0)", isadd64(0, 0) == 0);
+  TEST("isadd64(INT64_MAX, 0) boundary",
+       isadd64(9223372036854775807LL, 0) == 9223372036854775807LL);
+  TEST("isadd64(INT64_MAX, 1) pos overflow",
+       isadd64(9223372036854775807LL, 1) == 9223372036854775807LL);
+  TEST("isadd64(INT64_MIN, -1) neg overflow",
+       isadd64(-9223372036854775807LL - 1, -1) == -9223372036854775807LL - 1);
+  TEST("isadd64(1000000000000000000, 1000000000000000000) no overflow",
+       isadd64(1000000000000000000LL, 1000000000000000000LL) ==
+           2000000000000000000LL);
 }
 
 void test_saturating_sub(void) {
+  // 8-bit unsigned
   TEST("ssub8(0, 0)", ssub8(0, 0) == 0);
   TEST("ssub8(0, 1) underflow", ssub8(0, 1) == 0);
   TEST("ssub8(10, 20) underflow", ssub8(10, 20) == 0);
   TEST("ssub8(255, 0) boundary", ssub8(255, 0) == 255);
   TEST("ssub8(100, 50) no underflow", ssub8(100, 50) == 50);
 
+  // 16-bit unsigned
+  TEST("ssub16(0, 0)", ssub16(0, 0) == 0);
+  TEST("ssub16(0, 1) underflow", ssub16(0, 1) == 0);
+  TEST("ssub16(1000, 2000) underflow", ssub16(1000, 2000) == 0);
+  TEST("ssub16(65535, 0) boundary", ssub16(65535, 0) == 65535);
+  TEST("ssub16(50000, 25000) no underflow", ssub16(50000, 25000) == 25000);
+
+  // 32-bit unsigned
+  TEST("ssub32(0, 0)", ssub32(0, 0) == 0);
+  TEST("ssub32(0, 1) underflow", ssub32(0, 1) == 0);
+  TEST("ssub32(1000000, 2000000) underflow", ssub32(1000000, 2000000) == 0);
+  TEST("ssub32(0xFFFFFFFF, 0) boundary", ssub32(0xFFFFFFFFU, 0) == 0xFFFFFFFFU);
+  TEST("ssub32(0x80000000, 0x40000000) no underflow",
+       ssub32(0x80000000U, 0x40000000U) == 0x40000000U);
+
+  // 64-bit unsigned
+  TEST("ssub64(0, 0)", ssub64(0, 0) == 0);
+  TEST("ssub64(0, 1) underflow", ssub64(0, 1) == 0);
+  TEST("ssub64(1000000000000, 2000000000000) underflow",
+       ssub64(1000000000000ULL, 2000000000000ULL) == 0);
+  TEST("ssub64(0xFFFFFFFFFFFFFFFF, 0) boundary",
+       ssub64(0xFFFFFFFFFFFFFFFFULL, 0) == 0xFFFFFFFFFFFFFFFFULL);
+  TEST("ssub64(0x8000000000000000, 0x4000000000000000) no underflow",
+       ssub64(0x8000000000000000ULL, 0x4000000000000000ULL) ==
+           0x4000000000000000ULL);
+
+  // 8-bit signed
   TEST("issub8(0, 0)", issub8(0, 0) == 0);
   TEST("issub8(127, -1) pos overflow", issub8(127, -1) == 127);
   TEST("issub8(100, -50) pos overflow", issub8(100, -50) == 127);
   TEST("issub8(-128, 1) neg overflow", issub8(-128, 1) == -128);
   TEST("issub8(-100, 50) neg overflow", issub8(-100, 50) == -128);
   TEST("issub8(50, 25) no overflow", issub8(50, 25) == 25);
+
+  // 16-bit signed
+  TEST("issub16(0, 0)", issub16(0, 0) == 0);
+  TEST("issub16(32767, -1) pos overflow", issub16(32767, -1) == 32767);
+  TEST("issub16(20000, -20000) pos overflow", issub16(20000, -20000) == 32767);
+  TEST("issub16(-32768, 1) neg overflow", issub16(-32768, 1) == -32768);
+  TEST("issub16(-20000, 20000) neg overflow", issub16(-20000, 20000) == -32768);
+  TEST("issub16(10000, 5000) no overflow", issub16(10000, 5000) == 5000);
+
+  // 32-bit signed
+  TEST("issub32(0, 0)", issub32(0, 0) == 0);
+  TEST("issub32(INT32_MAX, -1) pos overflow", issub32(2147483647, -1) == 2147483647);
+  TEST("issub32(2000000000, -200000000) pos overflow",
+       issub32(2000000000, -200000000) == 2147483647);
+  TEST("issub32(INT32_MIN, 1) neg overflow",
+       issub32(-2147483647 - 1, 1) == -2147483647 - 1);
+  TEST("issub32(-2000000000, 200000000) neg overflow",
+       issub32(-2000000000, 200000000) == -2147483647 - 1);
+  TEST("issub32(1000000000, 500000000) no overflow",
+       issub32(1000000000, 500000000) == 500000000);
+
+  // 64-bit signed
+  TEST("issub64(0, 0)", issub64(0, 0) == 0);
+  TEST("issub64(INT64_MAX, -1) pos overflow",
+       issub64(9223372036854775807LL, -1) == 9223372036854775807LL);
+  TEST("issub64(INT64_MIN, 1) neg overflow",
+       issub64(-9223372036854775807LL - 1, 1) == -9223372036854775807LL - 1);
+  TEST("issub64(1000000000000000000, 500000000000000000) no overflow",
+       issub64(1000000000000000000LL, 500000000000000000LL) ==
+           500000000000000000LL);
 }
 
 void test_pow(void) {
@@ -169,13 +303,38 @@ void test_pow(void) {
 }
 
 void test_parity(void) {
+  // 8-bit
   TEST("is_even8(0)", is_even8(0));
   TEST("is_even8(2)", is_even8(2));
   TEST("is_even8(255) false", !is_even8(255));
-
   TEST("is_odd8(0) false", !is_odd8(0));
   TEST("is_odd8(1)", is_odd8(1));
   TEST("is_odd8(255)", is_odd8(255));
+
+  // 16-bit
+  TEST("is_even16(0)", is_even16(0));
+  TEST("is_even16(65534)", is_even16(65534));
+  TEST("is_even16(65535) false", !is_even16(65535));
+  TEST("is_odd16(0) false", !is_odd16(0));
+  TEST("is_odd16(1)", is_odd16(1));
+  TEST("is_odd16(65535)", is_odd16(65535));
+
+  // 32-bit
+  TEST("is_even32(0)", is_even32(0));
+  TEST("is_even32(0xFFFFFFFE)", is_even32(0xFFFFFFFEU));
+  TEST("is_even32(0xFFFFFFFF) false", !is_even32(0xFFFFFFFFU));
+  TEST("is_odd32(0) false", !is_odd32(0));
+  TEST("is_odd32(1)", is_odd32(1));
+  TEST("is_odd32(0xFFFFFFFF)", is_odd32(0xFFFFFFFFU));
+
+  // 64-bit
+  TEST("is_even64(0)", is_even64(0));
+  TEST("is_even64(0xFFFFFFFFFFFFFFFE)", is_even64(0xFFFFFFFFFFFFFFFEULL));
+  TEST("is_even64(0xFFFFFFFFFFFFFFFF) false",
+       !is_even64(0xFFFFFFFFFFFFFFFFULL));
+  TEST("is_odd64(0) false", !is_odd64(0));
+  TEST("is_odd64(1)", is_odd64(1));
+  TEST("is_odd64(0xFFFFFFFFFFFFFFFF)", is_odd64(0xFFFFFFFFFFFFFFFFULL));
 }
 
 void test_get_bit(void) {
@@ -469,41 +628,114 @@ void test_absdiff_properties(void) {
 }
 
 void test_saturating_add_properties(void) {
-  PROPTEST("saturating add properties");
+  PROPTEST("saturating add properties (8/16/32/64-bit)");
 
   for (int trial = 0; trial < PROPERTY_TEST_TRIALS; trial++) {
-    uint8_t a = (uint8_t)rand();
-    uint8_t b = (uint8_t)rand();
+    // 8-bit tests
+    uint8_t a8 = (uint8_t)rand();
+    uint8_t b8 = (uint8_t)rand();
+    uint8_t result8 = sadd8(a8, b8);
 
-    uint8_t result = sadd8(a, b);
-
-    // Property: result is in valid range [0, 255]
-    // Always true for uint8_t
-
-    // Property: identity sadd(x, 0) == x
-    if (sadd8(a, 0) != a) {
-      PROPFAIL("identity failed: a=%u sadd(a,0)=%u", a, sadd8(a, 0));
+    if (sadd8(a8, 0) != a8) {
+      PROPFAIL("sadd8 identity failed: a=%u", a8);
       return;
     }
-
-    // Property: commutativity
-    if (sadd8(a, b) != sadd8(b, a)) {
-      PROPFAIL("commutativity failed: a=%u b=%u sadd(a,b)=%u sadd(b,a)=%u", a,
-               b, sadd8(a, b), sadd8(b, a));
+    if (sadd8(a8, b8) != sadd8(b8, a8)) {
+      PROPFAIL("sadd8 commutativity failed: a=%u b=%u", a8, b8);
       return;
     }
-
-    // Property: saturation at boundary
-    if ((uint16_t)a + (uint16_t)b > 255) {
-      if (result != 255) {
-        PROPFAIL("overflow saturation failed: a=%u b=%u result=%u expected=255",
-                 a, b, result);
+    if ((uint16_t)a8 + (uint16_t)b8 > 0xFF) {
+      if (result8 != 0xFF) {
+        PROPFAIL("sadd8 overflow: a=%u b=%u result=%u expected=255", a8, b8,
+                 result8);
         return;
       }
     } else {
-      if (result != (uint8_t)(a + b)) {
-        PROPFAIL("no overflow failed: a=%u b=%u result=%u expected=%u", a, b,
-                 result, (uint8_t)(a + b));
+      if (result8 != (uint8_t)(a8 + b8)) {
+        PROPFAIL("sadd8 no overflow: a=%u b=%u result=%u expected=%u", a8, b8,
+                 result8, (uint8_t)(a8 + b8));
+        return;
+      }
+    }
+
+    // 16-bit tests
+    uint16_t a16 = (uint16_t)rand();
+    uint16_t b16 = (uint16_t)rand();
+    uint16_t result16 = sadd16(a16, b16);
+
+    if (sadd16(a16, 0) != a16) {
+      PROPFAIL("sadd16 identity failed: a=%u", a16);
+      return;
+    }
+    if (sadd16(a16, b16) != sadd16(b16, a16)) {
+      PROPFAIL("sadd16 commutativity failed: a=%u b=%u", a16, b16);
+      return;
+    }
+    if ((uint32_t)a16 + (uint32_t)b16 > 0xFFFF) {
+      if (result16 != 0xFFFF) {
+        PROPFAIL("sadd16 overflow: a=%u b=%u result=%u expected=65535", a16, b16,
+                 result16);
+        return;
+      }
+    } else {
+      if (result16 != (uint16_t)(a16 + b16)) {
+        PROPFAIL("sadd16 no overflow: a=%u b=%u result=%u expected=%u", a16, b16,
+                 result16, (uint16_t)(a16 + b16));
+        return;
+      }
+    }
+
+    // 32-bit tests
+    uint32_t a32 = (uint32_t)rand() | ((uint32_t)rand() << 16);
+    uint32_t b32 = (uint32_t)rand() | ((uint32_t)rand() << 16);
+    uint32_t result32 = sadd32(a32, b32);
+
+    if (sadd32(a32, 0) != a32) {
+      PROPFAIL("sadd32 identity failed: a=%u", a32);
+      return;
+    }
+    if (sadd32(a32, b32) != sadd32(b32, a32)) {
+      PROPFAIL("sadd32 commutativity failed: a=%u b=%u", a32, b32);
+      return;
+    }
+    if ((uint64_t)a32 + (uint64_t)b32 > 0xFFFFFFFFU) {
+      if (result32 != 0xFFFFFFFFU) {
+        PROPFAIL("sadd32 overflow: a=%u b=%u result=%u expected=0xFFFFFFFF", a32,
+                 b32, result32);
+        return;
+      }
+    } else {
+      if (result32 != (uint32_t)(a32 + b32)) {
+        PROPFAIL("sadd32 no overflow: a=%u b=%u result=%u expected=%u", a32, b32,
+                 result32, (uint32_t)(a32 + b32));
+        return;
+      }
+    }
+
+    // 64-bit tests
+    uint64_t a64 = ((uint64_t)rand() << 32) | rand();
+    uint64_t b64 = ((uint64_t)rand() << 32) | rand();
+    uint64_t result64 = sadd64(a64, b64);
+
+    if (sadd64(a64, 0) != a64) {
+      PROPFAIL("sadd64 identity failed");
+      return;
+    }
+    if (sadd64(a64, b64) != sadd64(b64, a64)) {
+      PROPFAIL("sadd64 commutativity failed");
+      return;
+    }
+    // Check overflow: if a64 > MAX - b64, overflow occurred
+    if (a64 > 0xFFFFFFFFFFFFFFFFULL - b64) {
+      if (result64 != 0xFFFFFFFFFFFFFFFFULL) {
+        PROPFAIL("sadd64 overflow: result=%llu expected=0xFFFFFFFFFFFFFFFF",
+                 (unsigned long long)result64);
+        return;
+      }
+    } else {
+      if (result64 != a64 + b64) {
+        PROPFAIL("sadd64 no overflow: result=%llu expected=%llu",
+                 (unsigned long long)result64, (unsigned long long)(a64 + b64));
         return;
       }
     }
@@ -513,34 +745,97 @@ void test_saturating_add_properties(void) {
 }
 
 void test_saturating_sub_properties(void) {
-  PROPTEST("saturating sub properties");
+  PROPTEST("saturating sub properties (8/16/32/64-bit)");
 
   for (int trial = 0; trial < PROPERTY_TEST_TRIALS; trial++) {
-    uint8_t a = (uint8_t)rand();
-    uint8_t b = (uint8_t)rand();
+    // 8-bit tests
+    uint8_t a8 = (uint8_t)rand();
+    uint8_t b8 = (uint8_t)rand();
+    uint8_t result8 = ssub8(a8, b8);
 
-    uint8_t result = ssub8(a, b);
-
-    // Property: result is in valid range [0, 255]
-    // Always true for uint8_t
-
-    // Property: identity ssub(x, 0) == x
-    if (ssub8(a, 0) != a) {
-      PROPFAIL("identity failed: a=%u ssub(a,0)=%u", a, ssub8(a, 0));
+    if (ssub8(a8, 0) != a8) {
+      PROPFAIL("ssub8 identity failed: a=%u", a8);
       return;
     }
-
-    // Property: underflow saturation
-    if (a < b) {
-      if (result != 0) {
-        PROPFAIL("underflow saturation failed: a=%u b=%u result=%u expected=0",
-                 a, b, result);
+    if (a8 < b8) {
+      if (result8 != 0) {
+        PROPFAIL("ssub8 underflow: a=%u b=%u result=%u expected=0", a8, b8,
+                 result8);
         return;
       }
     } else {
-      if (result != (uint8_t)(a - b)) {
-        PROPFAIL("no underflow failed: a=%u b=%u result=%u expected=%u", a, b,
-                 result, (uint8_t)(a - b));
+      if (result8 != (uint8_t)(a8 - b8)) {
+        PROPFAIL("ssub8 no underflow: a=%u b=%u result=%u expected=%u", a8, b8,
+                 result8, (uint8_t)(a8 - b8));
+        return;
+      }
+    }
+
+    // 16-bit tests
+    uint16_t a16 = (uint16_t)rand();
+    uint16_t b16 = (uint16_t)rand();
+    uint16_t result16 = ssub16(a16, b16);
+
+    if (ssub16(a16, 0) != a16) {
+      PROPFAIL("ssub16 identity failed: a=%u", a16);
+      return;
+    }
+    if (a16 < b16) {
+      if (result16 != 0) {
+        PROPFAIL("ssub16 underflow: a=%u b=%u result=%u expected=0", a16, b16,
+                 result16);
+        return;
+      }
+    } else {
+      if (result16 != (uint16_t)(a16 - b16)) {
+        PROPFAIL("ssub16 no underflow: a=%u b=%u result=%u expected=%u", a16,
+                 b16, result16, (uint16_t)(a16 - b16));
+        return;
+      }
+    }
+
+    // 32-bit tests
+    uint32_t a32 = (uint32_t)rand() | ((uint32_t)rand() << 16);
+    uint32_t b32 = (uint32_t)rand() | ((uint32_t)rand() << 16);
+    uint32_t result32 = ssub32(a32, b32);
+
+    if (ssub32(a32, 0) != a32) {
+      PROPFAIL("ssub32 identity failed: a=%u", a32);
+      return;
+    }
+    if (a32 < b32) {
+      if (result32 != 0) {
+        PROPFAIL("ssub32 underflow: a=%u b=%u result=%u expected=0", a32, b32,
+                 result32);
+        return;
+      }
+    } else {
+      if (result32 != (uint32_t)(a32 - b32)) {
+        PROPFAIL("ssub32 no underflow: a=%u b=%u result=%u expected=%u", a32,
+                 b32, result32, (uint32_t)(a32 - b32));
+        return;
+      }
+    }
+
+    // 64-bit tests
+    uint64_t a64 = ((uint64_t)rand() << 32) | rand();
+    uint64_t b64 = ((uint64_t)rand() << 32) | rand();
+    uint64_t result64 = ssub64(a64, b64);
+
+    if (ssub64(a64, 0) != a64) {
+      PROPFAIL("ssub64 identity failed");
+      return;
+    }
+    if (a64 < b64) {
+      if (result64 != 0) {
+        PROPFAIL("ssub64 underflow: result=%llu expected=0",
+                 (unsigned long long)result64);
+        return;
+      }
+    } else {
+      if (result64 != a64 - b64) {
+        PROPFAIL("ssub64 no underflow: result=%llu expected=%llu",
+                 (unsigned long long)result64, (unsigned long long)(a64 - b64));
         return;
       }
     }

--- a/sunscreen-llvm.nix
+++ b/sunscreen-llvm.nix
@@ -4,7 +4,7 @@
 { lib, stdenv, fetchurl, autoPatchelfHook, zlib }:
 
 let
-  version = "2025.11.21";
+  version = "2025.11.24";
   fileVersion = builtins.replaceStrings [ "." ] [ "-" ] version;
   urlBase =
     "https://github.com/Sunscreen-tech/sunscreen-llvm/releases/download/v${version}";


### PR DESCRIPTION
Implement constant pool support for i64 and i128 constants in the Parasol backend. Constants are stored in .rodata.cst8 and .rodata.cst16 sections and loaded via LOAD instructions with absolute addressing. Zero constants are optimized to use the X0 register directly.

Test files include comprehensive i64 and i128 test cases, as well as alignment verification tests.

# Pull Request Checklist

Please ensure that your pull request addresses the following points:

- [ ] Have any of the opcode or instruction bit formatting changed in a breaking way?
    - If yes, please bump the ABI version in `llvm/lib/Target/Parasol/MCTargetDesc/ParasolELFObjectWriter.cpp`.
- [x] Run `./format-parasol.sh` from the root directory to ensure your code is properly formatted.
- [x] Updated the license-sunscreen-changes.txt with any changes to comply with the AGPLv3 and Apache licenses.
- [x] Ensured that any files in this PR contain the Sunscreen license notice.

## Release Checklist (if creating a new release)

If this PR is for creating a new release, use `./release-all.sh` to build all architectures and update the Nix configuration:

```bash
./release-all.sh              # Uses today's date
./release-all.sh 2025.11.21   # Custom version
```

The script builds macOS (native) and Linux (Docker) tarballs, calculates hashes, and updates `sunscreen-llvm.nix`.

Before merging:
- [x] Review changes: `git diff sunscreen-llvm.nix`
- [x] Commit: `git add sunscreen-llvm.nix && git commit -m 'chore: release vYYYY.MM.DD'`

After PR is merged:
- [ ] Create tag on main branch: `git tag vYYYY.MM.DD`
- [ ] Push tag: `git push origin vYYYY.MM.DD`
- [ ] Create GitHub release with tarballs from `releases/` directory

---

Thank you for your contribution to the Sunscreen LLVM fork!
