### PR TITLE
External scratch buffer no longer needed in parasol library header

### DIFF
--- a/clang/lib/Headers/parasol.h
+++ b/clang/lib/Headers/parasol.h
@@ -339,8 +339,6 @@ static inline bool get_bit32(uint32_t value, unsigned int n) {
 //
 // Reductions:
 // - Require len > 0 (undefined behavior if len == 0)
-// - min/max require scratch buffer with len elements of same type as array
-// - sum/avg require scratch buffer with len elements of uint64_t/int64_t
 // - sum operations may overflow for large arrays (wraps modulo 2^64)
 //
 // Bitonic sort:
@@ -351,8 +349,8 @@ static inline bool get_bit32(uint32_t value, unsigned int n) {
 
 // Tree reduction for min - finds minimum element in array
 #define DEFINE_MIN_ARRAY(SUFFIX, TYPE, SELECT_FUNC)                            \
-  static inline TYPE min##SUFFIX##_array(const TYPE *arr, uint16_t len,        \
-                                         TYPE *scratch) {                      \
+  static inline TYPE min##SUFFIX##_array(const TYPE *arr, uint16_t len) {      \
+    TYPE *scratch = (TYPE *)malloc(len * sizeof(TYPE));                        \
     for (uint32_t i = 0; i < len; i++) {                                       \
       scratch[i] = arr[i];                                                     \
     }                                                                          \
@@ -374,8 +372,8 @@ static inline bool get_bit32(uint32_t value, unsigned int n) {
 
 // Tree reduction for max - finds maximum element in array
 #define DEFINE_MAX_ARRAY(SUFFIX, TYPE, SELECT_FUNC)                            \
-  static inline TYPE max##SUFFIX##_array(const TYPE *arr, uint16_t len,        \
-                                         TYPE *scratch) {                      \
+  static inline TYPE max##SUFFIX##_array(const TYPE *arr, uint16_t len) {      \
+    TYPE *scratch = (TYPE *)malloc(len * sizeof(TYPE));                        \
     for (uint32_t i = 0; i < len; i++) {                                       \
       scratch[i] = arr[i];                                                     \
     }                                                                          \
@@ -397,8 +395,8 @@ static inline bool get_bit32(uint32_t value, unsigned int n) {
 
 // Tree reduction for sum - uses wider accumulator to reduce overflow risk
 #define DEFINE_SUM_ARRAY(NAME, INPUT_TYPE, SUM_TYPE)                           \
-  static inline SUM_TYPE NAME##_array(const INPUT_TYPE *arr, uint16_t len,     \
-                                      SUM_TYPE *scratch) {                     \
+  static inline SUM_TYPE NAME##_array(const INPUT_TYPE *arr, uint16_t len) {   \
+    SUM_TYPE *scratch = (SUM_TYPE *)malloc(len * sizeof(SUM_TYPE));            \
     for (uint32_t i = 0; i < len; i++) {                                       \
       scratch[i] = (SUM_TYPE)arr[i];                                           \
     }                                                                          \
@@ -469,7 +467,9 @@ static inline bool get_bit32(uint32_t value, unsigned int n) {
 // Signed type wrappers that add 'i' prefix correctly
 #define DEFINE_MIN_ARRAY_SIGNED(BITS)                                          \
   static inline int##BITS##_t imin##BITS##_array(                              \
-      const int##BITS##_t *arr, uint16_t len, int##BITS##_t *scratch) {        \
+      const int##BITS##_t *arr, uint16_t len) {                                \
+    int##BITS##_t *scratch =                                                   \
+        (int##BITS##_t *)malloc(len * sizeof(int##BITS##_t));                  \
     for (uint32_t i = 0; i < len; i++) {                                       \
       scratch[i] = arr[i];                                                     \
     }                                                                          \
@@ -491,7 +491,9 @@ static inline bool get_bit32(uint32_t value, unsigned int n) {
 
 #define DEFINE_MAX_ARRAY_SIGNED(BITS)                                          \
   static inline int##BITS##_t imax##BITS##_array(                              \
-      const int##BITS##_t *arr, uint16_t len, int##BITS##_t *scratch) {        \
+      const int##BITS##_t *arr, uint16_t len) {                                \
+    int##BITS##_t *scratch =                                                   \
+        (int##BITS##_t *)malloc(len * sizeof(int##BITS##_t));                  \
     for (uint32_t i = 0; i < len; i++) {                                       \
       scratch[i] = arr[i];                                                     \
     }                                                                          \


### PR DESCRIPTION
# Pull Request Checklist

Please ensure that your pull request addresses the following points:

- [ ] Have any of the opcode or instruction bit formatting changed in a breaking way?
    - If yes, please bump the ABI version in `llvm/lib/Target/Parasol/MCTargetDesc/ParasolELFObjectWriter.cpp`.
- [ ] Run `./format-parasol.sh` from the root directory to ensure your code is properly formatted.
- [ ] Updated the license-sunscreen-changes.txt with any changes to comply with the AGPLv3 and Apache licenses.
- [ ] Ensured that any files in this PR contain the Sunscreen license notice.

## Release Checklist (if creating a new release)

If this PR is for creating a new release, use `./release-all.sh` to build all architectures and update the Nix configuration:

```bash
./release-all.sh              # Uses today's date
./release-all.sh 2025.11.21   # Custom version
```

The script builds macOS (native) and Linux (Docker) tarballs, calculates hashes, and updates `sunscreen-llvm.nix`.

Before merging:
- [ ] Review changes: `git diff sunscreen-llvm.nix`
- [ ] Commit: `git add sunscreen-llvm.nix && git commit -m 'chore: release vYYYY.MM.DD'`

After PR is merged:
- [ ] Create tag on main branch: `git tag vYYYY.MM.DD`
- [ ] Push tag: `git push origin vYYYY.MM.DD`
- [ ] Create GitHub release with tarballs from `releases/` directory

---

Thank you for your contribution to the Sunscreen LLVM fork!
